### PR TITLE
Github Actions: upload artifact

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,23 +1,25 @@
-name: RunelitePlus continuous integration
 
-on: [pull_request, push]
+name: CI Nightly Artifacts
+
+on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: windows-latest
-
+    runs-on: windows-latest    
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Assembling
-        run: gradlew assemble --console=plain
-      - name: Building
-        run: gradlew build --stacktrace -x test -x checkstyleMain --console=plain
-      - name: Testing
-        run: gradlew test --stacktrace --console=plain
-      - name: Checking code conventions
-        run: gradlew checkstyleMain --console=plain
+    - uses: actions/checkout@v1
+    - run: curl -O "https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-fx-jdk8.0.222-win_x64.zip"
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        architecture: x64
+        jdkFile: ./zulu8.40.0.25-ca-fx-jdk8.0.222-win_x64.zip
+        
+    - run: |
+        ./gradlew assemble -x test -x checkstyleMain
+        ./gradlew build -x test -x checkstyleMain
+               
+    - uses: actions/upload-artifact@v1.0.0
+      with:
+          name: RuneLitePlus-Nightlies.jar
+          path: ./runelite-client/build/libs


### PR DESCRIPTION
Also switches to JDK8. Can use this for nightly build, there are a few actions for deployment options like uploading as a Release, etc. Wasn't sure on which would be best to use