### PR TITLE
playerindicators: Fix agility overhead icons

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -180,14 +180,14 @@ public class PlayerIndicatorsOverlay extends Overlay
 								textLocation.getY() - height),
 							ImageUtil.resizeImage(agilityIcon, height, height));
 					}
-					else if (level >= plugin.getAgilitySecondThreshold())
+					if (level >= plugin.getAgilitySecondThreshold())
 					{
 						OverlayUtil.renderImageLocation(graphics,
 							new Point(textLocation.getX() + agilityIcon.getWidth() + width,
 								textLocation.getY() - height),
 							ImageUtil.resizeImage(agilityIcon, height, height));
 					}
-					else if (level < plugin.getAgilityFirstThreshold())
+					if (level < plugin.getAgilityFirstThreshold())
 					{
 						OverlayUtil.renderImageLocation(graphics,
 							new Point(textLocation.getX() + 5 + width,


### PR DESCRIPTION
When the plugin was re-implemented, the logic was copied incorrectly, you can see the original here: https://github.com/runelite-extended/runelite/commit/39fd5f6bacf2e926fc1746ec280cf99bb8b98b44#diff-07e1c0eea1fac0994278c3d53423df06R251-R276

As it is written currently, it never shows the second agility icon that should be shown when the second threshold is met