### PR TITLE
Add plugin version, used for tracking external plugin versions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -60,4 +60,9 @@ public @interface PluginDescriptor
 	boolean loadWhenOutdated() default false;
 
 	PluginType type() default PluginType.GENERAL_USE;
+
+	/**
+	 * Version of the plugin, mainly used for external plugins.
+	 */
+	String version() default "";
 }


### PR DESCRIPTION
So when writing external plugins it'll be super handy to have a version in the class so when distributing plugins users will know when the plugin they are using outdated.