### PR TITLE
api: Change menu events' setModifed so it can't change modified back to false

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.api.events;
 
-import lombok.Setter;
+import lombok.Getter;
 import net.runelite.api.MenuEntry;
 
 /**
@@ -44,11 +44,11 @@ public class MenuEntryAdded extends MenuEntry implements Event
 	 * Checks if count is the same, but doesn't check if there's
 	 * been multiple changes
 	 */
-	@Setter
+	@Getter
 	private boolean modified;
 
-	public boolean hasBeenModified()
+	public void setModified()
 	{
-		return modified;
+		this.modified = true;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOpened.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOpened.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.api.events;
 
+import lombok.AccessLevel;
+import lombok.Setter;
 import net.runelite.api.MenuEntry;
 import lombok.Data;
 
@@ -38,6 +40,7 @@ public class MenuOpened implements Event
 	 * in menuEntries is changed, so the changes can be
 	 * propagated through to the client.
 	 */
+	@Setter(AccessLevel.NONE)
 	private boolean modified;
 
 	/**
@@ -61,5 +64,10 @@ public class MenuOpened implements Event
 		}
 
 		return null;
+	}
+
+	public void setModified()
+	{
+		this.modified = true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -240,7 +240,7 @@ public class MenuManager
 
 		// Need to set the event entries to prevent conflicts
 		event.setMenuEntries(arrayEntries);
-		event.setModified(true);
+		event.setModified();
 	}
 
 	private void onMenuEntryAdded(MenuEntryAdded event)
@@ -889,7 +889,7 @@ public class MenuManager
 	}
 
 	@AllArgsConstructor
-	private class SortMapping implements Comparable<SortMapping>
+	private static class SortMapping implements Comparable<SortMapping>
 	{
 		private final int priority;
 		private final MenuEntry entry;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -541,7 +541,10 @@ public class AgilityPlugin extends Plugin
 			changed |= checkAndModify(entry);
 		}
 
-		event.setModified(changed);
+		if (changed)
+		{
+			event.setModified();
+		}
 	}
 
 	private boolean checkAndModify(MenuEntry old)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chattranslation/ChatTranslationPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chattranslation/ChatTranslationPlugin.java
@@ -202,7 +202,7 @@ public class ChatTranslationPlugin extends Plugin implements KeyListener
 			newEntries[i].setOpcode(MenuOpcode.RUNELITE.getId());
 
 			event.setMenuEntries(newEntries);
-			event.setModified(true);
+			event.setModified();
 
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpPlugin.java
@@ -258,7 +258,7 @@ public class CorpPlugin extends Plugin
 		}
 
 		event.setOpcode(NPC_SECOND_OPTION.getId() + MENU_ACTION_DEPRIORITIZE_OFFSET);
-		event.setModified(true);
+		event.setModified();
 	}
 
 	private void onConfigChanged(ConfigChanged configChanged)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -407,7 +407,7 @@ public class DevToolsPlugin extends Plugin
 			}
 
 			entry.setTarget(entry.getTarget() + " " + ColorUtil.prependColorTag("(" + info + ")", JagexColors.MENU_TARGET));
-			entry.setModified(true);
+			entry.setModified();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -448,7 +448,7 @@ public class GrandExchangePlugin extends Plugin
 			case WidgetID.SHOP_INVENTORY_GROUP_ID:
 				menuEntry.setOption(SEARCH_GRAND_EXCHANGE);
 				menuEntry.setOpcode(MenuOpcode.RUNELITE.getId());
-				menuEntry.setModified(true);
+				menuEntry.setModified();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -983,7 +983,7 @@ public class GroundItemsPlugin extends Plugin
 				{
 					final String optionText = telegrabEntry ? "Cast" : "Take";
 					lastEntry.setOption(ColorUtil.prependColorTag(optionText, color));
-					lastEntry.setModified(true);
+					lastEntry.setModified();
 				}
 
 				if (mode == BOTH || mode == NAME)
@@ -1003,14 +1003,14 @@ public class GroundItemsPlugin extends Plugin
 					}
 
 					lastEntry.setTarget(target);
-					lastEntry.setModified(true);
+					lastEntry.setModified();
 				}
 			}
 
 			if (this.showMenuItemQuantities && itemComposition.isStackable() && quantity > 1)
 			{
 				lastEntry.setTarget(lastEntry.getTarget() + " (" + quantity + ")");
-				lastEntry.setModified(true);
+				lastEntry.setModified();
 			}
 
 			if (this.removeIgnored && lastEntry.getOption().equals("Take") && hiddenItemList.contains(Text.removeTags(lastEntry.getTarget())))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -250,7 +250,7 @@ public class InventoryTagsPlugin extends Plugin
 
 			// Need to set the event entries to prevent conflicts
 			event.setMenuEntries(menuList);
-			event.setModified(true);
+			event.setModified();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -578,7 +578,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		}
 
 		event.setMenuEntries(menu_entries.toArray(new MenuEntry[0]));
-		event.setModified(true);
+		event.setModified();
 	}
 
 	public void onMenuEntryAdded(MenuEntryAdded event)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -311,7 +311,7 @@ public class NpcIndicatorsPlugin extends Plugin
 		{
 			final String target = ColorUtil.prependColorTag(Text.removeTags(event.getTarget()), this.getHighlightColor);
 			event.setTarget(target);
-			event.setModified(true);
+			event.setModified();
 		}
 		else if (hotKeyPressed && type == MenuOpcode.EXAMINE_NPC.getId())
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -750,7 +750,7 @@ public abstract class RSClientMixin implements RSClient
 
 			client.getCallbacks().post(MenuEntryAdded.class, event);
 
-			if (event.hasBeenModified() && client.getMenuOptionCount() == newCount)
+			if (event.isModified() && client.getMenuOptionCount() == newCount)
 			{
 				options[oldCount] = event.getOption();
 				targets[oldCount] = event.getTarget();


### PR DESCRIPTION
This was causing a bug with agility plugin undoing other plugins' modifications to menuOpened events' menuentries if it started after the other plugin