### PR TITLE
coxhelper: fix teleport targets with spaces

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/coxhelper/CoxPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/coxhelper/CoxPlugin.java
@@ -223,7 +223,7 @@ public class CoxPlugin extends Plugin
 					{
 						final String fixedPlayerName = Text.sanitize(rawPlayerName);
 
-						if (fixedPlayerName.equals(tpMatcher.group(1)))
+						if (fixedPlayerName.equals(Text.sanitize(tpMatcher.group(1))))
 						{
 							victims.add(new Victim(player, Victim.Type.TELEPORT));
 						}


### PR DESCRIPTION
Sanitize the Regex match result since it still has nbsp in it.