### PR TITLE
menuentryswapper: Fix Remove objects wildcard

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -601,8 +601,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			for (final String object : removedObjects)
 			{
 				if (target.equals(object)
-					|| hasArrow && target.endsWith(object)
-					|| targetLength > object.length() && target.startsWith(object))
+					|| hasArrow && target.endsWith(object))
 				{
 					client.setMenuOptionCount(client.getMenuOptionCount() - 1);
 					return;


### PR DESCRIPTION
Removes line 605 of `MenuEntrySwapperPlugin.java`, which is as follows:
`targetLength > object.length() && target.startsWith(object))`

Previously if you added `Tree` to the `Remove objects` list, it will also remove `Tree Door`, `Tree Trunk`, or anything else that starts with `Tree`. This is meant to fix that. Build tested and working as expected.

Screenshot of previous bug:
https://whocodes.tech/upload/javaw_Qm7U0hkuxq.png