### PR TITLE
checkstyle: fix checkstyle-idea plugin for IntelliJ

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -28,7 +28,6 @@
 	"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
 	"https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
-	<module name="SuppressionCommentFilter"/>
 	<module name="TreeWalker">
 		<module name="LeftCurly">
 			<property name="option" value="nl"/>


### PR DESCRIPTION
removes unused checkstyle rules to allow the continued use of the checkstyle-idea plugin.