### PR TITLE
menuentryswapper: Hop to option for the menu swapper plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -44,6 +44,7 @@ import net.runelite.client.plugins.menuentryswapper.util.FairyRingMode;
 import net.runelite.client.plugins.menuentryswapper.util.FairyTreeMode;
 import net.runelite.client.plugins.menuentryswapper.util.GamesNecklaceMode;
 import net.runelite.client.plugins.menuentryswapper.util.GloryMode;
+import net.runelite.client.plugins.menuentryswapper.util.HopToMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseAdvertisementMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseMode;
 import net.runelite.client.plugins.menuentryswapper.util.MaxCapeMode;
@@ -836,6 +837,18 @@ public interface MenuEntrySwapperConfig extends Config
 	default CharterOption charterOption()
 	{
 		return CharterOption.TRADE;
+	}
+
+	@ConfigItem(
+			keyName = "HopTo",
+			name = "Hop-to",
+			description = "Changes the default option to hop to on ccs and friend lists",
+			position = 28,
+			section = "miscellaneousSection"
+	)
+	default HopToMode swapHopToMode()
+	{
+		return HopToMode.NONE;
 	}
 
 	//------------------------------------------------------------//

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -840,11 +840,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "HopTo",
-			name = "Hop-to",
-			description = "Changes the default option to hop to on ccs and friend lists",
-			position = 28,
-			section = "miscellaneousSection"
+		keyName = "HopTo",
+		name = "Hop-to",
+		description = "Changes the default option to hop-to on ccs and friend lists or both",
+		position = 28,
+		section = "miscellaneousSection"
 	)
 	default HopToMode swapHopToMode()
 	{
@@ -1370,11 +1370,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "swapFairyTree",
-			name = "Fairy Tree",
-			description = "Swap options on PoH Fairy Tree",
-			position = 2,
-			section = "teleportationSection"
+		keyName = "swapFairyTree",
+		name = "Fairy Tree",
+		description = "Swap options on PoH Fairy Tree",
+		position = 2,
+		section = "teleportationSection"
 	)
 	default boolean swapFairyTree()
 	{
@@ -1382,13 +1382,13 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "fairyTree",
-			name = "Mode",
-			description = "",
-			position = 3,
-			section = "teleportationSection",
-			hidden = true,
-			unhide = "swapFairyTree"
+		keyName = "fairyTree",
+		name = "Mode",
+		description = "",
+		position = 3,
+		section = "teleportationSection",
+		hidden = true,
+		unhide = "swapFairyTree"
 	)
 	default FairyTreeMode swapFairyTreeMode()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -107,6 +107,7 @@ import net.runelite.client.plugins.menuentryswapper.util.FairyRingMode;
 import net.runelite.client.plugins.menuentryswapper.util.FairyTreeMode;
 import net.runelite.client.plugins.menuentryswapper.util.GamesNecklaceMode;
 import net.runelite.client.plugins.menuentryswapper.util.GloryMode;
+import net.runelite.client.plugins.menuentryswapper.util.HopToMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseAdvertisementMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseMode;
 import net.runelite.client.plugins.menuentryswapper.util.JewelleryBoxDestination;
@@ -228,6 +229,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private String configCustomShiftSwaps;
 	private String configCustomSwaps;
 	private XericsTalismanMode getXericsTalismanMode;
+	private HopToMode swapHopToMode;
 	private boolean getBurningAmulet;
 	private boolean getCombatBracelet;
 	private boolean getDigsitePendant;
@@ -303,6 +305,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private boolean swapWildernessLever;
 
 	private JewelleryBoxDestination lastDes;
+
 
 	@Provides
 	MenuEntrySwapperConfig provideConfig(ConfigManager configManager)
@@ -1304,6 +1307,30 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			menuManager.addPriorityEntry(new GrimyHerbComparableEntry(this.swapGrimyHerbMode, client));
 		}
+
+		switch (this.swapHopToMode)
+		{
+			//.removePriorityEntry needed here to reset Priority
+			case FRIENDSLIST:
+				menuManager.removePriorityEntry("message");
+				menuManager.addPriorityEntry("hop-to").setPriority(1);
+				menuManager.addPriorityEntry("kick user").setPriority(100);
+				break;
+			case CLANCHAT:
+				menuManager.removePriorityEntry("kick user");
+				menuManager.addPriorityEntry("hop-to").setPriority(1);
+				menuManager.addPriorityEntry("message").setPriority(100);
+				break;
+			case BOTH:
+				menuManager.removePriorityEntry("message");
+				menuManager.removePriorityEntry("kick user");
+				menuManager.addPriorityEntry("hop-to").setPriority(100);
+				break;
+			case NONE:
+				menuManager.removePriorityEntry("hop-to");
+				menuManager.removePriorityEntry("kick user");
+				menuManager.removePriorityEntry("message");
+		}
 	}
 
 	private void removeSwaps()
@@ -1426,7 +1453,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry(this.questCapeMode.toString(), "quest point cape");
 		menuManager.removePriorityEntry(this.swapHouseAdMode.getEntry());
 		menuManager.removeSwap("Bury", "bone", "Use");
-		
+
 		switch (this.swapFairyRingMode)
 		{
 			case OFF:
@@ -1789,6 +1816,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		this.swapWildernessLever = config.swapWildernessLever();
 		this.swapHouseAd = config.swapHouseAd();
 		this.swapHouseAdMode = config.swapHouseAdMode();
+		this.swapHopToMode = config.swapHopToMode();
 	}
 
 	private void addBuySellEntries()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HopToMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HopToMode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2019, alanbaumgartner <https://github.com/alanbaumgartner>
+ * Copyright (c) 2019, Kyle <https://github.com/kyleeld>
+ * Copyright (c) 2019, Lucas <https://github.com/lucwousin>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper.util;
+
+public enum HopToMode
+{
+	NONE("None"),
+	CLANCHAT("Clan Chat"),
+	FRIENDSLIST("Friends List"),
+	BOTH("Both");
+
+
+	private final String name;
+
+	HopToMode(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Allows Hop-to be set as top priority for menu swapper for the friends list, clan chat, or both. The clan chat option closes #1809 . This is my first PR to the open-osrs project and im still learning the api so criticism/advice would be appreciated, so that I can make better and more substantial contributions.