### PR TITLE
project: ensure injector deps are built

### DIFF
--- a/injected-client/injected-client.gradle.kts
+++ b/injected-client/injected-client.gradle.kts
@@ -39,9 +39,6 @@ configurations {
 
 dependencies {
     "vanilla"(Libraries.vanilla)
-    implementation(project(":runelite-mixins"))
-    implementation(project(":runescape-api"))
-    implementation(project(":runescape-client"))
 }
 
 injector {
@@ -59,6 +56,11 @@ artifacts {
 
 // keep the sourcesets etc but remove useless tasks
 tasks {
+    build {
+        dependsOn(":runelite-mixins:build")
+        dependsOn(":runescape-api:build")
+        dependsOn(":runescape-client:build")
+    }
     classes {
         enabled = false
     }

--- a/injected-client/injected-client.gradle.kts
+++ b/injected-client/injected-client.gradle.kts
@@ -39,6 +39,9 @@ configurations {
 
 dependencies {
     "vanilla"(Libraries.vanilla)
+    implementation(project(":runelite-mixins"))
+    implementation(project(":runescape-api"))
+    implementation(project(":runescape-client"))
 }
 
 injector {


### PR DESCRIPTION
As a brand new project, every configuration I tried (including disabling configure on demand, parallel, and caching) resulted in Injection failing because rs-client and mixins jars hadn't been built yet. Enforcing the dependency solved the problem.

@Owain94 