### PR TITLE
menuentryswapper: implings remove only loot/use swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -640,7 +640,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 						}
 						else
 						{
-							menuManager.removeSwaps(target);
+							menuManager.removeSwap("loot", target, "use");
 						}
 					}
 					break;
@@ -657,7 +657,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 						}
 						else
 						{
-							menuManager.removeSwaps(target);
+							menuManager.removeSwap("loot", target, "use");
 						}
 					}
 					break;
@@ -674,7 +674,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 						}
 						else
 						{
-							menuManager.removeSwaps(target);
+							menuManager.removeSwap("loot", target, "use");
 						}
 					}
 					break;
@@ -693,7 +693,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 						}
 						else
 						{
-							menuManager.removeSwaps(target);
+							menuManager.removeSwap("loot", target, "use");
 						}
 					}
 					break;
@@ -711,7 +711,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 						}
 						else
 						{
-							menuManager.removeSwaps(target);
+							menuManager.removeSwap("loot", target, "use");
 						}
 					}
 					break;


### PR DESCRIPTION
Change MES Impling swaps to remove just the loot / use swap instead of removing all swaps which effects trying to add custom swaps/bank swaps


made new PR cos I lost the old branch