### PR TITLE
GauntletPlugin: Resource fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
@@ -352,19 +352,22 @@ public class GauntletPlugin extends Plugin
 				oresGathered++;
 				miningXp = event.getXp();
 			}
-			case FARMING:
+				break;
+			case FISHING:
 				if (fishingXp != event.getXp())
 				{
 					fishGathered++;
 					fishingXp = event.getXp();
 				}
+				break;
 			case WOODCUTTING:
 				if (woodcuttingXp != event.getXp())
 				{
 					woodGathered++;
 					woodcuttingXp = event.getXp();
 				}
-			case FISHING:
+				break;
+			case FARMING:
 				if (farmingXp != event.getXp())
 				{
 					if (currentFarmingAction == GATHERING_HERB)
@@ -378,6 +381,7 @@ public class GauntletPlugin extends Plugin
 						farmingXp = event.getXp();
 					}
 				}
+				break;
 		}
 		updateCounters();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
@@ -344,45 +344,40 @@ public class GauntletPlugin extends Plugin
 	@Subscribe
 	private void onStatsChanged(StatChanged event)
 	{
-		if (event.getSkill().name().toLowerCase().equals("mining"))
+		switch (event.getSkill())
 		{
-			if (miningXp != event.getXp())
+			case MINING:
+				if (miningXp != event.getXp())
 			{
 				oresGathered++;
 				miningXp = event.getXp();
 			}
-		}
-		if (event.getSkill().name().toLowerCase().equals("woodcutting"))
-		{
-			if (woodcuttingXp != event.getXp())
-			{
-				woodGathered++;
-				woodcuttingXp = event.getXp();
-			}
-		}
-		if (event.getSkill().name().toLowerCase().equals("farming"))
-		{
-			if (farmingXp != event.getXp())
-			{
-				if (currentFarmingAction == GATHERING_HERB)
+			case FARMING:
+				if (fishingXp != event.getXp())
 				{
-					herbGathered++;
-					farmingXp = event.getXp();
+					fishGathered++;
+					fishingXp = event.getXp();
 				}
-				else if (currentFarmingAction == GATHERING_CLOTH)
+			case WOODCUTTING:
+				if (woodcuttingXp != event.getXp())
 				{
-					clothGathered++;
-					farmingXp = event.getXp();
+					woodGathered++;
+					woodcuttingXp = event.getXp();
 				}
-			}
-		}
-		if (event.getSkill().name().toLowerCase().equals("fishing"))
-		{
-			if (fishingXp != event.getXp())
-			{
-				fishGathered++;
-				fishingXp = event.getXp();
-			}
+			case FISHING:
+				if (farmingXp != event.getXp())
+				{
+					if (currentFarmingAction == GATHERING_HERB)
+					{
+						herbGathered++;
+						farmingXp = event.getXp();
+					}
+					else if (currentFarmingAction == GATHERING_CLOTH)
+					{
+						clothGathered++;
+						farmingXp = event.getXp();
+					}
+				}
 		}
 		updateCounters();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
@@ -51,10 +51,19 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.Player;
 import net.runelite.api.Projectile;
 import net.runelite.api.ProjectileID;
-import net.runelite.api.Skill;
 import net.runelite.api.SoundEffectID;
 import net.runelite.api.Varbits;
-import net.runelite.api.events.*;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.GameObjectDespawned;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.ProjectileSpawned;
+import net.runelite.api.events.StatChanged;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
@@ -63,7 +72,6 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SkillIconManager;
-import net.runelite.client.game.XpDropEvent;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
@@ -359,7 +367,8 @@ public class GauntletPlugin extends Plugin
 				if (currentFarmingAction == GATHERING_HERB)
 				{
 					herbGathered++;
-					farmingXp = event.getXp();				}
+					farmingXp = event.getXp();
+				}
 				else if (currentFarmingAction == GATHERING_CLOTH)
 				{
 					clothGathered++;


### PR DESCRIPTION
Fix double resource counter and resource counter starting at 1

onXpDrop event fires off twice each xp gain.
Switched to onStatsChanged with checks added to make sure player is in gauntlet and resets when entered