### PR TITLE
bootstrap: fix

### DIFF
--- a/buildSrc/src/main/kotlin/BootstrapTask.kt
+++ b/buildSrc/src/main/kotlin/BootstrapTask.kt
@@ -44,7 +44,7 @@ open class BootstrapTask @Inject constructor(@Input val type: String) : DefaultT
             val version = splat[2]
             lateinit var path: String
 
-            if (it.file.name.contains(ProjectVersions.rlVersion)) {
+            if (it.file.name.contains(ProjectVersions.rlVersion) || it.file.name.contains("injection-annotations")) {
                 path = "https://github.com/open-osrs/hosting/raw/master/${type}/${it.file.name}"
             } else if (!group.contains("runelite")) {
                 path = "https://repo.maven.apache.org/maven2/" + group.replace(".", "/") + "/${name}/$version/${name}-$version"


### PR DESCRIPTION
bootstrap fix.

injection annotation now uses the GH raw jar instead of trying to go via the maven repo.