### PR TITLE
Client: Fix skill unpacking during bootstrap

### DIFF
--- a/runescape-client/src/main/java/BZip2Decompressor.java
+++ b/runescape-client/src/main/java/BZip2Decompressor.java
@@ -192,7 +192,7 @@ public final class BZip2Decompressor {
 		int[] var23 = null;
 		int[] var24 = null;
 		int[] var25 = null;
-		var0.blockSize100k = 1410065408;
+		var0.blockSize100k = 1;
 		if (SoundSystem.BZip2Decompressor_block == null) {
 			SoundSystem.BZip2Decompressor_block = new int[var0.blockSize100k * 100000];
 		}


### PR DESCRIPTION
Hi there!

I've been trying to launch the compiled `runescape-client` with my own applet loader and got this exception:

```java.lang.NegativeArraySizeException: -1530494976
	at BZip2Decompressor.BZip2Decompressor_decompress(BZip2Decompressor.java:197)
	at BZip2Decompressor.BZip2Decompressor_decompress(BZip2Decompressor.java:33)
	at Skills.decompressBytes(Skills.java:51)
	at AbstractArchive.decodeIndex(AbstractArchive.java:100)
	at Archive.write(Archive.java:184)
	at Client.doCycleJs5(Client.java:2611)
	at Client.doCycle(Client.java:1624)
	at GameShell.clientTick(GameShell.java:588)
	at GameShell.run(GameShell.java:916)
	at java.base/java.lang.Thread.run(Thread.java:830)
```

I compared the code with a previously decompiled version and discovered that this constant should be set to `1`. Now everything works fine.