### PR TITLE
StatusBars: Fix hide when our of combat ignored until first combat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
@@ -157,7 +157,8 @@ public class StatusBarsPlugin extends Plugin
 				overlayManager.add(overlay);
 			}
 		}
-		else if (lastCombatAction != null && Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > combatTimeout)
+		else if (lastCombatAction == null
+			|| (lastCombatAction != null && Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > combatTimeout))
 		{
 			overlayManager.remove(overlay);
 		}


### PR DESCRIPTION
When this option is enabled, status bars were only hidden after entering and leaving combat for the first time. This change allows the status bars to be correctly hidden without requiring entering then leaving combat.