### PR TITLE
gradle: use transitive rl-api dep

### DIFF
--- a/runelite-client/runelite-client.gradle.kts
+++ b/runelite-client/runelite-client.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation(Libraries.sentry)
     implementation(Libraries.slf4jApi)
     implementation(project(":http-api"))
-    implementation(project(":runelite-api"))
+    api(project(":runelite-api"))
     implementation(Libraries.naturalMouse)
 
     runtimeOnly(Libraries.trident)


### PR DESCRIPTION
runelite-api is a dependency of http-api. so we will use api instead of implementation.