### PR TITLE
project: publish all deps when bootstrapping

### DIFF
--- a/buildSrc/src/main/kotlin/BootstrapPlugin.kt
+++ b/buildSrc/src/main/kotlin/BootstrapPlugin.kt
@@ -30,11 +30,11 @@ class BootstrapPlugin : Plugin<Project> {
 
         tasks.withType<BootstrapTask> {
             dependsOn(bootstrapDependencies)
-
+            dependsOn("publish")
             dependsOn(project(":runelite-api").tasks["publish"])
             dependsOn(project(":runescape-api").tasks["publish"])
             dependsOn(project(":http-api").tasks["publish"])
-            dependsOn(project(":runelite-client").tasks["publish"])
+            dependsOn(project(":injected-client").tasks["publish"])
 
             this.clientJar = clientJar.singleFile
 
@@ -45,7 +45,8 @@ class BootstrapPlugin : Plugin<Project> {
                 }
                 copy {
                     from(
-                            "${parent?.projectDir}/runelite-client/build/repo/.",
+                            "${buildDir}/repo/.",
+                            "${parent?.projectDir}/injected-client/build/repo/.",
                             "${parent?.projectDir}/runelite-api/build/repo/.",
                             "${parent?.projectDir}/http-api/build/repo/.",
                             "${parent?.projectDir}/runescape-api/build/repo/."


### PR DESCRIPTION
Before, it was ignoring injected-client, now it will not.