### PR TITLE
mes: add an option to swap offer-all

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -475,7 +475,6 @@ public interface MenuEntrySwapperConfig extends Config
 	// Miscellaneous
 	//------------------------------------------------------------//
 
-
 	@ConfigItem(
 		keyName = "customSwaps",
 		name = "Custom Swaps",
@@ -509,6 +508,18 @@ public interface MenuEntrySwapperConfig extends Config
 	default String prioEntry()
 	{
 		return "";
+	}
+
+	@ConfigItem(
+		keyName = "getSwapOffer",
+		name = "Offer-All",
+		description = "Swap 'Offer', on trades with 'Offer-All'",
+		position = 3,
+		section = "miscellaneousSection"
+	)
+	default boolean getSwapOffer()
+	{
+		return false;
 	}
 
 	@ConfigItem(
@@ -1955,7 +1966,7 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return "";
 	}
-	
+
 	@ConfigItem(
 		keyName = "swapNpcContact",
 		name = "NPC Contact",
@@ -2033,7 +2044,7 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
 		keyName = "bankInvigorateItem",
 		name = "Bank - Left Click 'Invigorate'",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -144,7 +144,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		"miscellania", "grand exchange", "falador park", "dondakan's rock", "edgeville", "karamja",
 		"draynor village", "al kharid"
 	);
-		private static final List<String> npcContact = Arrays.asList(
+	private static final List<String> npcContact = Arrays.asList(
 		"honest jimmy", "bert the sandman", "advisor ghrim", "dark mage", "lanthus", "turael",
 		"mazchna", "vannaka", "chaeldar", "nieve", "steve", "duradel", "krystilia", "konar",
 		"murphy", "cyrisus", "smoggy", "ginea", "watson", "barbarian guard", "random"
@@ -299,6 +299,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private boolean swapTravel;
 	private boolean swapWildernessLever;
 	private boolean swapJewelleryBox;
+	private boolean getSwapOffer;
 	private final HotkeyListener hotkey = new HotkeyListener(() -> this.hotkeyMod)
 	{
 		@Override
@@ -821,6 +822,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			menuManager.addPriorityEntry("Tan <col=ff7000>All");
 		}
 
+		if (this.getSwapOffer)
+		{
+			menuManager.addPriorityEntry("Offer-All<col=ff9040>");
+		}
+
 		if (this.getSwapSawmill)
 		{
 			menuManager.addPriorityEntry("Buy-plank", "Sawmill operator");
@@ -1319,6 +1325,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry("Stun", "Hoop snake");
 		menuManager.removePriorityEntry("Take-boat");
 		menuManager.removePriorityEntry("Tan <col=ff7000>All");
+		menuManager.removePriorityEntry("Offer-All<col=ff9040>");
 		menuManager.removePriorityEntry("Teleport menu", "Portal nexus");
 		menuManager.removePriorityEntry("Teleport", "Crafting cape");
 		menuManager.removePriorityEntry("Teleport", "Crafting cape(t)");
@@ -1518,7 +1525,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			menuManager.addPriorityEntry("climb-up").setPriority(100);
 		}
-		
+
 		if (this.swapNpcContact)
 		{
 			for (String npccontact : npcContact)
@@ -1544,7 +1551,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry(new BankComparableEntry("equip", "", false));
 		menuManager.removePriorityEntry(new BankComparableEntry("invigorate", "", false));
 		menuManager.removePriorityEntry("climb-up");
-		
+
 		for (String npccontact : npcContact)
 		{
 			menuManager.removePriorityEntry(npccontact, "npc contact");
@@ -1788,6 +1795,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		this.bankEquipItem = config.bankEquipItem();
 		this.bankInvigorateItem = config.bankInvigorateItem();
 		this.swapNpcContact = config.swapNpcContact();
+		this.getSwapOffer = config.getSwapOffer();
 	}
 
 	private void addBuySellEntries()


### PR DESCRIPTION
This isn't really a full on fix, a better option would be to have a new comparable entry specifically for trading, similar to the withdraws and it'd have to compare with a standardized string. This however works for most use cases and is easy to implement.

Path of least resistance and all.