### PR TITLE
pvpTools: add clan wars to swaps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
@@ -632,7 +632,7 @@ public class PvpToolsPlugin extends Plugin
 		{
 			if ((client.getVar(Varbits.IN_RAID) == 1 || client.getVar(Varbits.THEATRE_OF_BLOOD) == 2)
 				|| (client.getVar(Varbits.IN_WILDERNESS) != 1 && !WorldType.isAllPvpWorld(client.getWorldType()))
-				|| (client.getVar(Varbits.IN_PVP_AREA) ==1))
+				|| (client.getVar(Varbits.IN_PVP_AREA) ==1 ))
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
@@ -632,7 +632,7 @@ public class PvpToolsPlugin extends Plugin
 		{
 			if ((client.getVar(Varbits.IN_RAID) == 1 || client.getVar(Varbits.THEATRE_OF_BLOOD) == 2)
 				|| (client.getVar(Varbits.IN_WILDERNESS) != 1 && !WorldType.isAllPvpWorld(client.getWorldType()))
-				|| (client.getVar(Varbits.IN_PVP_AREA) !=1))
+				|| (client.getVar(Varbits.IN_PVP_AREA) ==1))
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
@@ -632,7 +632,7 @@ public class PvpToolsPlugin extends Plugin
 		{
 			if ((client.getVar(Varbits.IN_RAID) == 1 || client.getVar(Varbits.THEATRE_OF_BLOOD) == 2)
 				|| (client.getVar(Varbits.IN_WILDERNESS) != 1 && !WorldType.isAllPvpWorld(client.getWorldType()))
-				|| (client.getVar(Varbits.IN_PVP_AREA) ==1 ))
+				|| (client.getVar(Varbits.IN_PVP_AREA) == 1))
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
@@ -631,7 +631,8 @@ public class PvpToolsPlugin extends Plugin
 		clientThread.invoke(() ->
 		{
 			if ((client.getVar(Varbits.IN_RAID) == 1 || client.getVar(Varbits.THEATRE_OF_BLOOD) == 2)
-				|| (client.getVar(Varbits.IN_WILDERNESS) != 1 && !WorldType.isAllPvpWorld(client.getWorldType())))
+				|| (client.getVar(Varbits.IN_WILDERNESS) != 1 && !WorldType.isAllPvpWorld(client.getWorldType()))
+				|| (client.getVar(Varbits.IN_PVP_AREA) !=1))
 			{
 				return;
 			}


### PR DESCRIPTION
Before the hide attack/cast options didn't work in clanwars due to the area it was in.

Line 634 could possibly be deleted as IN_PVP_AREA affects pvp, wilderness and clan wars.