### PR TITLE
WorldClient: Force Http Request to ignore local OkHttp cache

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/worlds/WorldClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/WorldClient.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import javax.inject.Inject;
 import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.CacheControl;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -60,6 +61,7 @@ public class WorldClient
 
 		Request request = new Request.Builder()
 			.url(url)
+			.cacheControl(CacheControl.FORCE_NETWORK)
 			.build();
 
 		try (Response response = client.newCall(request).execute())


### PR DESCRIPTION
```
2020-02-01 01:05:33 [pool-4-thread-1] WARN  n.runelite.client.game.WorldService - Error looking up worlds
java.io.IOException: com.google.gson.JsonIOException: java.io.IOException: failed to delete C:\Users\User\.runelite\cache\okhttp\b0c59f847558d67b40e6822c8b5f6d1f.1
    at net.runelite.http.api.worlds.WorldClient.lookupWorlds(WorldClient.java:78)
    at net.runelite.client.game.WorldService.fetch(WorldService.java:94)
    at net.runelite.client.game.WorldService.tick(WorldService.java:79)
    at net.runelite.client.util.RunnableExceptionLogger.run(RunnableExceptionLogger.java:41)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    at java.base/java.util.concurrent.FutureTask.runAndReset(Unknown Source)
    at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
    at java.base/java.lang.Thread.run(Unknown Source)
```

I believe there a race condition for competing IO calls across multiple clients. Some times when multiple clients are launched in quick succession, this error occurs and it breaks the default world / cli world loading. Seems to be an issue with the OkHttpClient cache.

The cache file in question is: `C:\Users\User\.runelite\cache\okhttp\b0c59f847558d67b40e6822c8b5f6d1f.1`
Which appears to be cached data for the `worlds.js` endpoint used by the `WorldClient`