### PR TITLE
mixins: change npcdefinitionchanged to behave identically to upstream

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
@@ -106,16 +106,20 @@ public abstract class RSNPCMixin implements RSNPC
 
 	@FieldHook(value = "definition", before = true)
 	@Inject
-	public void onDefinitionChanged(RSNPCDefinition composition)
+	public void onDefinitionChanged(RSNPCDefinition newDef)
 	{
-		if (composition == null)
+		if (newDef == null)
 		{
 			client.getCallbacks().post(NpcDespawned.class, new NpcDespawned(this));
+			return;
 		}
-		else if (this.getId() != -1)
+		RSNPCDefinition oldDef = getDefinition();
+		if (oldDef == null || oldDef.getId() == newDef.getId())
 		{
-			client.getCallbacks().post(NpcDefinitionChanged.class, new NpcDefinitionChanged(this));
+			return;
 		}
+
+		client.getCallbacks().postDeferred(NpcDefinitionChanged.class, new NpcDefinitionChanged(this));
 	}
 
 	@Copy("getModel")


### PR DESCRIPTION
Closes open-osrs/plugins#121

However, this breaks the slayer plugin and npc indicators ~~and some other naughty plugins~~
https://github.com/open-osrs/plugins/blob/master/slayer/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java#L377
https://github.com/open-osrs/plugins/blob/master/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java#L368