### PR TITLE
rs-client: Fix broken compare of last modified dates

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
@@ -74,6 +74,7 @@ class ExternalPf4jPluginManager extends DefaultPluginManager
 		if (isNotDevelopment())
 		{
 			JarPluginRepository jarPluginRepository = new JarPluginRepository(getPluginsRoot());
+			jarPluginRepository.setComparator(Comparator.comparingLong(File::lastModified));
 			compoundPluginRepository.add(jarPluginRepository);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
@@ -1,11 +1,13 @@
 package net.runelite.client.plugins;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
Loading plugins would give this error:
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.base/java.util.TimSort.mergeLo(Unknown Source)
	at java.base/java.util.TimSort.mergeAt(Unknown Source)
	at java.base/java.util.TimSort.mergeCollapse(Unknown Source)
	at java.base/java.util.TimSort.sort(Unknown Source)
	at java.base/java.util.Arrays.sort(Unknown Source)
	at org.pf4j.BasePluginRepository.getPluginPaths(BasePluginRepository.java:77)
	at org.pf4j.CompoundPluginRepository.getPluginPaths(CompoundPluginRepository.java:62)
	at net.runelite.client.plugins.ExternalPf4jPluginManager.loadPlugins(ExternalPf4jPluginManager.java:119)
	at net.runelite.client.plugins.ExternalPluginManager.startExternalPluginManager(ExternalPluginManager.java:196)
	at net.runelite.client.RuneLite.start(RuneLite.java:446)
	at net.runelite.client.RuneLite.main(RuneLite.java:401)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at net.runelite.launcher.ReflectionLauncher$1.run(ReflectionLauncher.java:64)

i didn't look into which exact plugin files were broken nor do i care, a proper comparator works fine