### PR TITLE
client: Set JarPluginRepository#comparator to null

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
@@ -74,6 +74,12 @@ class ExternalPf4jPluginManager extends DefaultPluginManager
 		if (isNotDevelopment())
 		{
 			JarPluginRepository jarPluginRepository = new JarPluginRepository(getPluginsRoot());
+
+			// Default pf4j comparator crashes on some systems (https://github.com/open-osrs/runelite/pull/2621)
+			// We also don't care about plugin order at this point, pf4j will sort by Plugin-Dependencies
+			// and we re-sort later based on `@PluginDependency`
+			jarPluginRepository.setComparator(null);
+
 			compoundPluginRepository.add(jarPluginRepository);
 		}
 


### PR DESCRIPTION
The default pf4j comparator casts longs to ints which breaks
the sort. Since we don't actually rely on this sorting, simply
set the comparator to `null`.

See https://github.com/open-osrs/runelite/pull/2621 for more info