### PR TITLE
Plugin-Panel: Add sorting plugins by repository

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/OpenOSRSConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/OpenOSRSConfig.java
@@ -40,7 +40,8 @@ public interface OpenOSRSConfig extends Config
 	enum SortStyle
 	{
 		CATEGORY("Category"),
-		ALPHABETICALLY("Alphabetically");
+		ALPHABETICALLY("Alphabetically"),
+		REPOSITORY("Repository");
 
 		private String name;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -382,7 +382,8 @@ public class PluginListPanel extends PluginPanel
 				Map<String, String> pluginInfoMap = externalPluginManager.getPluginsInfoMap().get(plugin.getClass().getSimpleName());
 				sectionName = pluginInfoMap.get("provider");
 			}
-			catch (NullPointerException e) {
+			catch (NullPointerException e)
+			{
 				sectionName = "Default";
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -384,7 +384,7 @@ public class PluginListPanel extends PluginPanel
 			}
 			catch (NullPointerException e)
 			{
-				sectionName = "Default";
+				sectionName = "System";
 			}
 
 			if (!sections.containsKey(sectionName))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -354,6 +354,51 @@ public class PluginListPanel extends PluginPanel
 			sections.get(sectionName).add(pluginListItem);
 		}
 
+		populateSections(sections);
+	}
+
+	private void generatePluginListByRepo(List<PluginListItem> pluginListItems)
+	{
+		final Map<String, JPanel> sections = new HashMap<>();
+
+		for (PluginListItem pluginListItem : pluginListItems)
+		{
+			if (pluginListItem.isPinned())
+			{
+				if (!sections.containsKey("Pinned"))
+				{
+					sections.put("Pinned", addSection("Pinned"));
+				}
+
+				sections.get("Pinned").add(pluginListItem);
+				continue;
+			}
+
+			Plugin plugin = pluginListItem.getPluginConfig().getPlugin();
+			String sectionName;
+
+			try
+			{
+				Map<String, String> pluginInfoMap = externalPluginManager.getPluginsInfoMap().get(plugin.getClass().getSimpleName());
+				sectionName = pluginInfoMap.get("provider");
+			}
+			catch (NullPointerException e) {
+				sectionName = "Default";
+			}
+
+			if (!sections.containsKey(sectionName))
+			{
+				sections.put(sectionName, addSection(sectionName));
+			}
+
+			sections.get(sectionName).add(pluginListItem);
+		}
+
+		populateSections(sections);
+	}
+
+	private void populateSections(Map<String, JPanel> sections)
+	{
 		sections.forEach((key, value) ->
 		{
 			Container parent = value.getParent();
@@ -376,7 +421,7 @@ public class PluginListPanel extends PluginPanel
 
 		if (text.isEmpty())
 		{
-			if (openOSRSConfig.pluginSortMode() == OpenOSRSConfig.SortStyle.ALPHABETICALLY || !openOSRSConfig.enableCategories())
+			if (openOSRSConfig.pluginSortMode() == OpenOSRSConfig.SortStyle.ALPHABETICALLY || (!openOSRSConfig.enableCategories() && (openOSRSConfig.pluginSortMode() != OpenOSRSConfig.SortStyle.REPOSITORY)))
 			{
 				pluginList.stream().filter(item -> pinned == item.isPinned()).forEach(mainPanel::add);
 			}
@@ -392,7 +437,7 @@ public class PluginListPanel extends PluginPanel
 			{
 				if (pinned == listItem.isPinned() && Text.matchesSearchTerms(searchTerms, listItem.getKeywords()))
 				{
-					if (openOSRSConfig.pluginSortMode() == OpenOSRSConfig.SortStyle.ALPHABETICALLY || !openOSRSConfig.enableCategories())
+					if (openOSRSConfig.pluginSortMode() == OpenOSRSConfig.SortStyle.ALPHABETICALLY || (!openOSRSConfig.enableCategories() && (openOSRSConfig.pluginSortMode() != OpenOSRSConfig.SortStyle.REPOSITORY)))
 					{
 						mainPanel.add(listItem);
 					}
@@ -407,6 +452,11 @@ public class PluginListPanel extends PluginPanel
 		if (openOSRSConfig.pluginSortMode() == OpenOSRSConfig.SortStyle.CATEGORY && openOSRSConfig.enableCategories())
 		{
 			generatePluginList(plugins);
+		}
+
+		if (openOSRSConfig.pluginSortMode() == OpenOSRSConfig.SortStyle.REPOSITORY)
+		{
+			generatePluginListByRepo(plugins);
 		}
 	}
 


### PR DESCRIPTION
Adds the option to sort plugins by their repository provider. Only does it in Categories because I couldn't find a solid way to sort it in this manner without Categories. The try/catch when getting the plugin provider is because some plugins do not have a provider, and are therefore given the "Default" category. 

For #2651  