### PR TITLE
client: Provide a scaling ExecutorService and use it from plugin managers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPluginManager.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Binder;
 import com.google.inject.CreationException;
 import com.google.inject.Injector;
@@ -48,7 +47,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -103,6 +101,7 @@ public class ExternalPluginManager
 	private final List<UpdateRepository> repositories = new ArrayList<>();
 	private final OpenOSRSConfig openOSRSConfig;
 	private final EventBus eventBus;
+	private final ExecutorService executorService;
 	private final ConfigManager configManager;
 	private final Map<String, String> pluginsMap = new HashMap<>();
 	@Getter(AccessLevel.PUBLIC)
@@ -119,12 +118,14 @@ public class ExternalPluginManager
 		PluginManager pluginManager,
 		OpenOSRSConfig openOSRSConfig,
 		EventBus eventBus,
+		ExecutorService executorService,
 		ConfigManager configManager,
 		Groups groups)
 	{
 		this.runelitePluginManager = pluginManager;
 		this.openOSRSConfig = openOSRSConfig;
 		this.eventBus = eventBus;
+		this.executorService = executorService;
 		this.configManager = configManager;
 		this.groups = groups;
 
@@ -465,62 +466,44 @@ public class ExternalPluginManager
 
 		final long start = System.currentTimeMillis();
 
-		// some plugins get stuck on IO, so add some extra threads
-		ExecutorService exec = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2,
-			new ThreadFactoryBuilder()
-				.setNameFormat("external-plugin-manager-%d")
-				.build());
-
-		try
+		List<Plugin> scannedPlugins = new CopyOnWriteArrayList<>();
+		sortedPlugins.forEach(group ->
 		{
-			List<Plugin> scannedPlugins = new CopyOnWriteArrayList<>();
-			sortedPlugins.forEach(group ->
-			{
-				List<Future<?>> curGroup = new ArrayList<>();
-				group.forEach(pluginClazz ->
-					curGroup.add(exec.submit(() ->
-					{
-						Plugin plugininst;
-						try
-						{
-							//noinspection unchecked
-							plugininst = instantiate(scannedPlugins, (Class<Plugin>) pluginClazz, init, initConfig);
-							scannedPlugins.add(plugininst);
-						}
-						catch (PluginInstantiationException e)
-						{
-							log.warn("Error instantiating plugin!", e);
-							return;
-						}
-
-						loaded.getAndIncrement();
-
-						RuneLiteSplashScreen.stage(.67, .75, "Loading external plugins", loaded.get(), scannedPlugins.size());
-					})));
-				curGroup.forEach(future ->
+			List<Future<?>> curGroup = new ArrayList<>();
+			group.forEach(pluginClazz ->
+				curGroup.add(executorService.submit(() ->
 				{
+					Plugin plugininst;
 					try
 					{
-						future.get();
+						//noinspection unchecked
+						plugininst = instantiate(scannedPlugins, (Class<Plugin>) pluginClazz, init, initConfig);
+						scannedPlugins.add(plugininst);
 					}
-					catch (InterruptedException | ExecutionException e)
+					catch (PluginInstantiationException e)
 					{
-						log.warn("Could not instantiate external plugin", e);
+						log.warn("Error instantiating plugin!", e);
+						return;
 					}
-				});
-			});
 
-			log.info("External plugin instantiation took {}ms", System.currentTimeMillis() - start);
-		}
-		finally
-		{
-			List<Runnable> unfinishedTasks = exec.shutdownNow();
-			if (!unfinishedTasks.isEmpty())
+					loaded.getAndIncrement();
+
+					RuneLiteSplashScreen.stage(.67, .75, "Loading external plugins", loaded.get(), scannedPlugins.size());
+				})));
+			curGroup.forEach(future ->
 			{
-				// This shouldn't happen since we Future#get all tasks submitted to the executor
-				log.warn("Did not complete all update tasks: {}", unfinishedTasks);
-			}
-		}
+				try
+				{
+					future.get();
+				}
+				catch (InterruptedException | ExecutionException e)
+				{
+					log.warn("Could not instantiate external plugin", e);
+				}
+			});
+		});
+
+		log.info("External plugin instantiation took {}ms", System.currentTimeMillis() - start);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -51,6 +51,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -134,6 +136,7 @@ public class ClientUI
 	private final MouseManager mouseManager;
 	private final Applet client;
 	private final ConfigManager configManager;
+	private final ExecutorService executorService;
 	private final Provider<ClientThread> clientThreadProvider;
 	private final EventBus eventBus;
 	private final CardLayout cardLayout = new CardLayout();
@@ -161,6 +164,7 @@ public class ClientUI
 		MouseManager mouseManager,
 		@Nullable Applet client,
 		ConfigManager configManager,
+		ExecutorService executorService,
 		Provider<ClientThread> clientThreadProvider,
 		EventBus eventbus)
 	{
@@ -169,6 +173,7 @@ public class ClientUI
 		this.mouseManager = mouseManager;
 		this.client = client;
 		this.configManager = configManager;
+		this.executorService = executorService;
 		this.clientThreadProvider = clientThreadProvider;
 		this.eventBus = eventbus;
 
@@ -601,9 +606,21 @@ public class ClientUI
 		saveClientBoundsConfig();
 		ClientShutdown csev = new ClientShutdown();
 		eventBus.post(ClientShutdown.class, csev);
+		executorService.shutdown();
+
 		new Thread(() ->
 		{
 			csev.waitForAllConsumers(Duration.ofSeconds(10));
+			try
+			{
+				if (!executorService.awaitTermination(5, TimeUnit.SECONDS))
+				{
+					executorService.shutdownNow();
+				}
+			}
+			catch (InterruptedException ignored)
+			{
+			}
 
 			if (client != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/util/NonScheduledExecutorServiceExceptionLogger.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/NonScheduledExecutorServiceExceptionLogger.java
@@ -1,0 +1,109 @@
+package net.runelite.client.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import static net.runelite.client.util.RunnableExceptionLogger.wrap;
+import org.jetbrains.annotations.NotNull;
+
+// Awkward name because plugins already referenced the ExecutorServiceExceptionLogger
+// (which only handles ScheduledExecutorServices) before this class was introduced
+public class NonScheduledExecutorServiceExceptionLogger implements ExecutorService
+{
+	private final ExecutorService service;
+
+	public NonScheduledExecutorServiceExceptionLogger(ExecutorService service)
+	{
+		this.service = service;
+	}
+
+	@Override
+	public void shutdown()
+	{
+		service.shutdown();
+	}
+
+	@NotNull
+	@Override
+	public List<Runnable> shutdownNow()
+	{
+		return service.shutdownNow();
+	}
+
+	@Override
+	public boolean isShutdown()
+	{
+		return service.isShutdown();
+	}
+
+	@Override
+	public boolean isTerminated()
+	{
+		return service.isTerminated();
+	}
+
+	@Override
+	public boolean awaitTermination(long timeout, @NotNull TimeUnit unit) throws InterruptedException
+	{
+		return service.awaitTermination(timeout, unit);
+	}
+
+	@Override
+	public void execute(@NotNull Runnable command)
+	{
+		service.execute(wrap(command));
+	}
+
+	@NotNull
+	@Override
+	public <T> Future<T> submit(@NotNull Callable<T> task)
+	{
+		return service.submit(CallableExceptionLogger.wrap(task));
+	}
+
+	@NotNull
+	@Override
+	public <T> Future<T> submit(@NotNull Runnable task, T result)
+	{
+		return service.submit(wrap(task), result);
+	}
+
+	@NotNull
+	@Override
+	public Future<?> submit(@NotNull Runnable task)
+	{
+		return service.submit(wrap(task));
+	}
+
+	@NotNull
+	@Override
+	public <T> List<Future<T>> invokeAll(@NotNull Collection<? extends Callable<T>> tasks) throws InterruptedException
+	{
+		return service.invokeAll(tasks);
+	}
+
+	@NotNull
+	@Override
+	public <T> List<Future<T>> invokeAll(@NotNull Collection<? extends Callable<T>> tasks, long timeout, @NotNull TimeUnit unit) throws InterruptedException
+	{
+		return service.invokeAll(tasks, timeout, unit);
+	}
+
+	@NotNull
+	@Override
+	public <T> T invokeAny(@NotNull Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException
+	{
+		return service.invokeAny(tasks);
+	}
+
+	@Override
+	public <T> T invokeAny(@NotNull Collection<? extends Callable<T>> tasks, long timeout, @NotNull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
+	{
+		return service.invokeAny(tasks, timeout, unit);
+	}
+}


### PR DESCRIPTION
The new ExecutorService is configured to consume up to 2*CPU threads
and will queue tasks when all threads are busy. Threads are created
as needed, and will be disposed of after 1 minute of inactivity.