### PR TITLE
client: Add inputs & output definitions to script assembler plugin

### DIFF
--- a/runelite-client/runelite-client.gradle.kts
+++ b/runelite-client/runelite-client.gradle.kts
@@ -148,6 +148,12 @@ tasks {
         archiveClassifier.set("shaded")
     }
 
+    processResources {
+        dependsOn(":runelite-script-assembler-plugin:indexMojo")
+
+        from("${buildDir}/scripts")
+    }
+
     withType<BootstrapTask> {
         group = "openosrs"
     }

--- a/runelite-script-assembler-plugin/runelite-script-assembler-plugin.gradle.kts
+++ b/runelite-script-assembler-plugin/runelite-script-assembler-plugin.gradle.kts
@@ -39,28 +39,34 @@ dependencies {
 
 tasks {
     register<JavaExec>("assembleMojo") {
+        inputs.files(
+                fileTree("${project.extra["rootPath"]}/runelite-client/src/main/scripts")
+        )
+
+        outputs.dir("${project.extra["rootPath"]}/runelite-client/build/scripts/runelite");
+
         classpath = project.sourceSets.main.get().runtimeClasspath
         main = "net.runelite.script.AssembleMojo"
         args(listOf(
                 "${project.extra["rootPath"]}/runelite-client/src/main/scripts",
-                "${project.extra["rootPath"]}/runelite-client/src/main/resources/runelite"
+                "${project.extra["rootPath"]}/runelite-client/build/scripts/runelite"
         ))
     }
 
     register<JavaExec>("indexMojo") {
+        inputs.files(
+            fileTree("${project.extra["rootPath"]}/runelite-client/build/scripts/runelite")
+        )
+
+        outputs.file("${project.extra["rootPath"]}/runelite-client/build/scripts/runelite/index");
+
         dependsOn("assembleMojo")
 
         classpath = project.sourceSets.main.get().runtimeClasspath
         main = "net.runelite.script.IndexMojo"
         args(listOf(
-                "${project.extra["rootPath"]}/runelite-client/src/main/resources/runelite",
-                "${project.extra["rootPath"]}/runelite-client/src/main/resources/runelite/index"
+                "${project.extra["rootPath"]}/runelite-client/build/scripts/runelite",
+                "${project.extra["rootPath"]}/runelite-client/build/scripts/runelite/index"
         ))
-    }
-
-    compileJava {
-        outputs.upToDateWhen {false}
-
-        finalizedBy("indexMojo")
     }
 }

--- a/runelite-script-assembler-plugin/src/main/java/net/runelite/script/AssembleMojo.java
+++ b/runelite-script-assembler-plugin/src/main/java/net/runelite/script/AssembleMojo.java
@@ -25,6 +25,8 @@
 package net.runelite.script;
 
 import com.google.common.io.Files;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -85,6 +87,16 @@ public class AssembleMojo extends AbstractMojo
 		int count = 0;
 		File scriptOut = new File(outputDirectory, Integer.toString(IndexType.CLIENTSCRIPT.getNumber()));
 		scriptOut.mkdirs();
+
+		// Clear the target directory to remove stale entries
+		try
+		{
+			MoreFiles.deleteDirectoryContents(scriptOut.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+		}
+		catch (IOException e)
+		{
+			throw new MojoExecutionException("Could not clear scriptOut: " + scriptOut, e);
+		}
 
 		for (File scriptFile : scriptDirectory.listFiles((dir, name) -> name.endsWith(".rs2asm")))
 		{


### PR DESCRIPTION
Also have assembler scripts be output into build directory.

Partially fixes #2665, though it's still a hack to use JavaExec like this. But turning it into a proper plugin requires splitting it out of the module build afaik, and that is a pain because it depends on the cache module.