### PR TITLE
rl-api: fix the rest of the incorrect equip-your-char widgets

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -888,23 +888,23 @@ public class WidgetID
 	static class EquipmentWidgetIdentifiers
 	{
 		static final int EQUIP_YOUR_CHARACTER = 3;
-		static final int STAB_ATTACK_BONUS = 23;
-		static final int SLASH_ATTACK_BONUS = 24;
-		static final int CRUSH_ATTACK_BONUS = 25;
-		static final int MAGIC_ATTACK_BONUS = 26;
-		static final int RANGED_ATTACK_BONUS = 27;
-		static final int STAB_DEFENCE_BONUS = 29;
-		static final int SLASH_DEFENCE_BONUS = 30;
-		static final int CRUSH_DEFENCE_BONUS = 31;
-		static final int MAGIC_DEFENCE_BONUS = 32;
-		static final int RANGED_DEFENCE_BONUS = 33;
+		static final int STAB_ATTACK_BONUS = 24;
+		static final int SLASH_ATTACK_BONUS = 25;
+		static final int CRUSH_ATTACK_BONUS = 26;
+		static final int MAGIC_ATTACK_BONUS = 27;
+		static final int RANGED_ATTACK_BONUS = 28;
+		static final int STAB_DEFENCE_BONUS = 30;
+		static final int SLASH_DEFENCE_BONUS = 31;
+		static final int CRUSH_DEFENCE_BONUS = 32;
+		static final int MAGIC_DEFENCE_BONUS = 33;
+		static final int RANGED_DEFENCE_BONUS = 34;
 		static final int MELEE_STRENGTH = 36;
 		static final int RANGED_STRENGTH = 37;
 		static final int MAGIC_DAMAGE = 38;
-		static final int PRAYER_BONUS = 38;
-		static final int UNDEAD_DAMAGE_BONUS = 40;
-		static final int SLAYER_DAMAGE_BONUS = 41;
-		static final int WEIGHT = 43;
+		static final int PRAYER_BONUS = 39;
+		static final int UNDEAD_DAMAGE_BONUS = 41;
+		static final int SLAYER_DAMAGE_BONUS = 42;
+		static final int WEIGHT = 49;
 	}
 
 	static class VarrockMuseum


### PR DESCRIPTION
Should have done this with the last one, but tunnel vision.