### PR TITLE
entityhidermixin: hide named npcs interacting

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1635,6 +1635,14 @@ public interface Client extends GameShell
 	void setAttackersHidden(boolean state);
 
 	/**
+	 * Sets whether hidden npcs are always hidden regardless
+	 * of interacting state (i.e. attacking).
+	 *
+	 * @param state hidden state
+	 */
+	void setAlwaysHideNamedNpcs(boolean state);
+
+	/**
 	 * Hides players input here.
 	 *
 	 * @param names the names of the players

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -71,6 +71,9 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public static boolean hideAttackers;
 
 	@Inject
+	public static boolean alwaysHideNamedNpcs;
+
+	@Inject
 	public static boolean hideProjectiles;
 
 	@Inject
@@ -249,6 +252,13 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public void setAttackersHidden(boolean state)
 	{
 		hideAttackers = state;
+	}
+
+	@Inject
+	@Override
+	public void setAlwaysHideNamedNpcs(boolean state)
+	{
+		alwaysHideNamedNpcs = state;
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -93,6 +93,9 @@ public abstract class EntityHiderMixin implements RSScene
 	@Shadow("hideAttackers")
 	private static boolean hideAttackers;
 
+	@Shadow("alwaysHideNamedNpcs")
+	private static boolean alwaysHideNamedNpcs;
+
 	@Shadow("hideProjectiles")
 	private static boolean hideProjectiles;
 
@@ -179,6 +182,12 @@ public abstract class EntityHiderMixin implements RSScene
 		else if (entity instanceof RSNPC)
 		{
 			RSNPC npc = (RSNPC) entity;
+
+			if (alwaysHideNamedNpcs && npc.getName() != null
+				&& hiddenNpcsName.getOrDefault(Text.standardize(npc.getName().toLowerCase()), 0) > 0)
+			{
+				return false;
+			}
 
 			if (!hideAttackers)
 			{


### PR DESCRIPTION
Add an option to hide only "attackers" that are in the Hide NPCs Names config list. The current hideAttackers option blanket hides all NPCs.

Use case: hide Kalphite Workers in the KQ multicombat zone