### PR TITLE
configmanager: write all of our config items to our properties

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -49,12 +49,16 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Stack;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -692,7 +696,7 @@ public class ConfigManager
 			return;
 		}
 
-		for (Method method : clazz.getDeclaredMethods())
+		for (Method method : getAllDeclaredInterfaceMethods(clazz))
 		{
 			ConfigItem item = method.getAnnotation(ConfigItem.class);
 
@@ -808,6 +812,25 @@ public class ConfigManager
 				log.warn("unable to save configuration file", ex);
 			}
 		}
+	}
+
+	/**
+	 * Does DFS on a class's interfaces to find all of its implemented methods.
+	 */
+	private Collection<Method> getAllDeclaredInterfaceMethods(Class<?> clazz)
+	{
+		Collection<Method> methods = new HashSet<>();
+		Stack<Class<?>> interfazes = new Stack<>();
+		interfazes.push(clazz);
+
+		while (!interfazes.isEmpty())
+		{
+			Class<?> interfaze = interfazes.pop();
+			Collections.addAll(methods, interfaze.getDeclaredMethods());
+			Collections.addAll(interfazes, interfaze.getInterfaces());
+		}
+
+		return methods;
 	}
 
 	private void syncLastModified()


### PR DESCRIPTION
A lot of plugins put all of their configuration into one file, making for very large files.

I'd like to break up my configuration to avoid these large files, e.g. in Kotlin:

```
@ConfigGroup("my.config.group")
interface MyConfig : MyConfigA, MyConfigB, Config {
    @JvmDefault
    @ConfigItem(...)
    fun hello() = ...
}

interface MyConfigA {
    @JvmDefault
    @ConfigItem(...)
    fun a() = ...
}

interface MyConfigB {
    @JvmDefault
    @ConfigItem(...)
    fun b() = ...
}
```

The above example actually works fine for simple types. Any default values not written to the properties file would just be written later on when you'd change them. However, enumerations are a different story because of the [following line in ConfigPanel.java](https://github.com/open-osrs/runelite/blob/64da9b0ed1e3f4641b6ab55a336d1f4cc6ca5885/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java#L929-L934):

```
Enum selectedItem = Enum.valueOf(type, configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName()));
```

Because default values are not written on startup, the `configManager` returns `null` for whatever key it looked up, causing the following NPE:
```
java.lang.NullPointerException: Name is null
	at java.base/java.lang.Enum.valueOf(Enum.java:238)
	at net.runelite.client.plugins.config.ConfigPanel.rebuild(ConfigPanel.java:931)
	at net.runelite.client.plugins.config.ConfigPanel.init(ConfigPanel.java:248)
	at net.runelite.client.plugins.config.PluginListPanel.openConfigurationPanel(PluginListPanel.java:489)
...
```

By getting all of our interface's methods including its superinterfaces', we're able to avoid the above error for configurations broken up across several interfaces.