### PR TITLE
client: fix first time bootup failure

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -701,6 +701,9 @@ public class PluginListPanel extends PluginPanel
 
 	public void sortPluginList(Comparator<PluginListItem> comparator)
 	{
+		if (pluginList == null)
+		return;
+		
 		if (comparator != null)
 		{
 			pluginList.sort(comparator.thenComparing(ev -> ev.getPluginConfig().getName()));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -702,7 +702,7 @@ public class PluginListPanel extends PluginPanel
 	public void sortPluginList(Comparator<PluginListItem> comparator)
 	{
 		if (pluginList == null)
-		return;
+			return;
 		
 		if (comparator != null)
 		{


### PR DESCRIPTION
This fixes a long standing problem.

On first time startup for OPRS, pluginList will return null, and plugins installed during that first bootup will no longer update in the list.
Requiring every single new user to restart the client at least once before using any new plugins.