### PR TITLE
gradle: catch grgit errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,8 +50,12 @@ plugins {
     application
 }
 
-val grgit = Grgit.open(mapOf("dir" to rootProject.projectDir.absolutePath))
-val localGitCommit = grgit.head().id
+val localGitCommit = try {
+    val projectPath = rootProject.projectDir.absolutePath
+    Grgit.open(mapOf("dir" to projectPath)).head().id
+} catch (_: Exception) {
+    "n/a"
+}
 
 fun isNonStable(version: String): Boolean {
     return listOf("ALPHA", "BETA", "RC").any {


### PR DESCRIPTION
Grgit fails when the project is a submodule. See https://github.com/ajoberstar/grgit/issues/80.

You can reproduce this by trying to build the project as a submodule. We'd get an _Access is denied_ error.

Further, if you search the Discord for _access is denied_, you'll find similar issues for this line. I doubt everybody is using submodules, but the cause of the error is evidently grgit. The error likely comes from expecting a file with executable permissions (like a directory), but finding a plaintext file (like in the case of a submodule).

This PR catches any errors and falls back to just shelling out and running `git rev-parse HEAD` instead. I abstract this functionality to a new `Utilities.kt` file in the `buildSrc` dir.

Alternatively, I propose we just remove the grgit library entirely. It's only used to get the hash, and shelling out works in both cases, and reports a much better error than the existing approach if there is an error. Lemme know what y'all think.