### PR TITLE
mixins: simplify dynamic object and sequence definition mixins

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/KeyPressedMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/KeyPressedMixin.java
@@ -30,7 +30,7 @@ import net.runelite.api.mixins.Shadow;
 import net.runelite.rs.api.RSClient;
 
 @Mixin(RSClient.class)
-public abstract class KeyHandlerMixin implements RSClient
+public abstract class KeyPressedMixin implements RSClient
 {
 	@Shadow("client")
 	private static RSClient client;

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSDynamicObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSDynamicObjectMixin.java
@@ -43,9 +43,6 @@ public abstract class RSDynamicObjectMixin implements RSDynamicObject
 	@Shadow("client")
 	private static RSClient client;
 
-	@Inject
-	public int animationID;
-
 	@SuppressWarnings("InfiniteRecursion")
 	@Copy("getModel")
 	@Replace("getModel")
@@ -88,8 +85,6 @@ public abstract class RSDynamicObjectMixin implements RSDynamicObject
 	@Inject
 	public void rl$init(int id, int type, int orientation, int plane, int x, int y, int animationID, boolean var8, RSEntity var9)
 	{
-		this.animationID = animationID;
-
 		if (animationID != -1)
 		{
 			DynamicObjectAnimationChanged dynamicObjectAnimationChanged = new DynamicObjectAnimationChanged();
@@ -103,6 +98,6 @@ public abstract class RSDynamicObjectMixin implements RSDynamicObject
 	@Override
 	public int getAnimationID()
 	{
-		return animationID;
+		return (int) (getSequenceDefinition() == null ? -1 : getSequenceDefinition().getHash());
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSSequenceDefinitionMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSSequenceDefinitionMixin.java
@@ -76,7 +76,7 @@ public abstract class RSSequenceDefinitionMixin implements RSSequenceDefinition
 
 		RSModel animatedModel = model.toSharedModel(!frames.getFrames()[frameIdx].isShowing());
 		animatedModel.interpolateFrames(frames, frameIdx, nextFrames, nextFrameIdx, interval,
-			getFrameLenths()[frame]);
+			getFrameLengths()[frame]);
 		return animatedModel;
 	}
 
@@ -136,7 +136,7 @@ public abstract class RSSequenceDefinitionMixin implements RSSequenceDefinition
 			animatedModel.rotateY90Ccw();
 		}
 		animatedModel.interpolateFrames(frames, frameIdx, nextFrames, nextFrameIdx, interval,
-			getFrameLenths()[frame]);
+			getFrameLengths()[frame]);
 		// reapply rotation after animating
 		if (rotation == 1)
 		{
@@ -194,7 +194,7 @@ public abstract class RSSequenceDefinitionMixin implements RSSequenceDefinition
 
 		RSModel animatedModel = model.toSharedSpotAnimModel(!frames.getFrames()[frameIdx].isShowing());
 		animatedModel.interpolateFrames(frames, frameIdx, nextFrames, nextFrameIdx, interval,
-			getFrameLenths()[frame]);
+			getFrameLengths()[frame]);
 		return animatedModel;
 	}
 
@@ -264,15 +264,15 @@ public abstract class RSSequenceDefinitionMixin implements RSSequenceDefinition
 			RSModel animatedModel = model.toSharedModel(!frames.getFrames()[frameIdx].isShowing()
 				& !chatFrames.getFrames()[chatFrameIdx].isShowing());
 			animatedModel.interpolateFrames(frames, frameIdx, nextFrames, nextFrameIdx, interval,
-				getFrameLenths()[frame]);
+				getFrameLengths()[frame]);
 			animatedModel.interpolateFrames(chatFrames, chatFrameIdx, nextChatFrames, nextChatFrameIdx,
-				interval, getFrameLenths()[frame]);
+				interval, getFrameLengths()[frame]);
 			return animatedModel;
 		}
 
 		RSModel animatedModel = model.toSharedModel(!frames.getFrames()[frameIdx].isShowing());
 		animatedModel.interpolateFrames(frames, frameIdx, nextFrames, nextFrameIdx, interval,
-			getFrameLenths()[frame]);
+			getFrameLengths()[frame]);
 		return animatedModel;
 	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSDynamicObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSDynamicObject.java
@@ -17,4 +17,7 @@ public interface RSDynamicObject extends RSEntity, DynamicObject, Entity
 
 	@Import("cycleStart")
 	int getAnimCycleCount();
+
+	@Import("sequenceDefinition")
+	RSSequenceDefinition getSequenceDefinition();
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSSequenceDefinition.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSSequenceDefinition.java
@@ -2,7 +2,7 @@ package net.runelite.rs.api;
 
 import net.runelite.mapping.Import;
 
-public interface RSSequenceDefinition
+public interface RSSequenceDefinition extends RSNode
 {
 //	@Import("stretches")
 //	boolean getStretches();
@@ -23,7 +23,7 @@ public interface RSSequenceDefinition
 	int[] getFrameIDs();
 
 	@Import("frameLengths")
-	int[] getFrameLenths();
+	int[] getFrameLengths();
 
 	@Import("chatFrameIds")
 	int[] getChatFrameIds();


### PR DESCRIPTION
We don't need to keep the `animationId` field around in DynamicObject, we can instead access the tag of the SequenceDefinition to get the animation id, preventing any potential confusion in future. Also fixes a typo in the sequence definition mixin and rsapi files, and renames KeyHandlerMixin to not conflict with an rs-client class, removing more potential confusion.