### PR TITLE
HTTP-API: Ignore snapshots for the runelite API.

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -218,7 +218,7 @@ public class RuneLiteAPI
 			for (int i = 0; i != versionList.getLength(); i++)
 			{
 				Node node = versionList.item(i);
-				if (node.getTextContent() != null)
+				if (node.getTextContent() != null && !node.getTextContent().endsWith("SNAPSHOT"))
 				{
 					upstreamVersion = node.getTextContent();
 				}


### PR DESCRIPTION
As of now runelite doesnt support this link:
https://api.runelite.net/runelite-1.6.33-SNAPSHOT/worlds.js

When ignoring the SNAPSHOT version it takes the heighest version which isnt a snapshot.