### PR TITLE
mixins: move menuaction print to after event

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1394,14 +1394,6 @@ public abstract class RSClientMixin implements RSClient
 			target = target.substring(10);
 		}
 
-		if (printMenuActions && client.getLogger().isDebugEnabled())
-		{
-			client.getLogger().debug(
-				"|MenuAction|: MenuOption={} MenuTarget={} Id={} Opcode={} Param0={} Param1={} CanvasX={} CanvasY={} Authentic={}",
-				option, target, id, opcode, param0, param1, canvasX, canvasY, authentic
-			);
-		}
-
 		/* Along the way, the RuneScape client may change a menuAction by incrementing it with 2000.
 		 * I have no idea why, but it does. Their code contains the same conditional statement.
 		 */
@@ -1427,6 +1419,16 @@ public abstract class RSClientMixin implements RSClient
 		if (menuOptionClicked.isConsumed())
 		{
 			return;
+		}
+
+		if (printMenuActions)
+		{
+			client.getLogger().info(
+				"|MenuAction|: MenuOption={} MenuTarget={} Id={} Opcode={} Param0={} Param1={} CanvasX={} CanvasY={} Authentic={}",
+				menuOptionClicked.getOption(), menuOptionClicked.getTarget(), menuOptionClicked.getIdentifier(),
+				menuOptionClicked.getOpcode(), menuOptionClicked.getParam0(), menuOptionClicked.getParam1(),
+				canvasX, canvasY, authentic
+			);
 		}
 
 		copy$menuAction(menuOptionClicked.getParam0(), menuOptionClicked.getParam1(), menuOptionClicked.getOpcode(),


### PR DESCRIPTION
The event can modify the action, so we print what the action is after the event fires.