### PR TITLE
mixins: Fix posting of WidgetPressed event

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/MenuMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/MenuMixin.java
@@ -26,9 +26,10 @@ package net.runelite.mixins;
 
 import net.runelite.api.MenuEntry;
 import net.runelite.api.events.WidgetPressed;
-import net.runelite.api.mixins.FieldHook;
+import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
 import net.runelite.api.mixins.Shadow;
 import net.runelite.rs.api.RSClient;
 import net.runelite.rs.api.RSFont;
@@ -193,14 +194,13 @@ public abstract class MenuMixin implements RSClient
 		getMenuForceLeftClick()[i] = entry.isForceLeftClick();
 	}
 
-	@Inject
-	@FieldHook("tempMenuAction")
-	public static void onTempMenuActionChanged(int idx)
+	@SuppressWarnings("InfiniteRecursion")
+	@Replace("setTempMenuAction")
+	@Copy("setTempMenuAction")
+	static void copy$setTempMenuAction(int arg)
 	{
-		if (tempMenuAction != null)
-		{
-			client.getCallbacks().post(WidgetPressed.class, WidgetPressed.INSTANCE);
-		}
+		copy$setTempMenuAction(arg);
+		client.getCallbacks().post(WidgetPressed.class, WidgetPressed.INSTANCE);
 	}
 
 	@Inject

--- a/runescape-client/src/main/java/AbstractByteArrayCopier.java
+++ b/runescape-client/src/main/java/AbstractByteArrayCopier.java
@@ -88,7 +88,8 @@ public abstract class AbstractByteArrayCopier {
 		descriptor = "(II)V",
 		garbageValue = "407362763"
 	)
-	static void method4087(int var0) {
+	@Export("setTempMenuAction")
+	static void setTempMenuAction(int var0) {
 		GrandExchangeOffer.tempMenuAction = new MenuAction(); // L: 11020
 		GrandExchangeOffer.tempMenuAction.param0 = Client.menuArguments1[var0]; // L: 11021
 		GrandExchangeOffer.tempMenuAction.param1 = Client.menuArguments2[var0]; // L: 11022

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -6047,7 +6047,7 @@ public final class Client extends GameShell implements Usernamed {
 				draggedWidgetX = MouseHandler.MouseHandler_lastPressedX; // L: 7859
 				draggedWidgetY = MouseHandler.MouseHandler_lastPressedY; // L: 7860
 				if (var2 >= 0) { // L: 7861
-					AbstractByteArrayCopier.method4087(var2);
+					AbstractByteArrayCopier.setTempMenuAction(var2);
 				}
 
 				GrandExchangeOfferOwnWorldComparator.invalidateWidget(GameBuild.dragInventoryWidget); // L: 7862

--- a/runescape-client/src/main/java/class228.java
+++ b/runescape-client/src/main/java/class228.java
@@ -93,7 +93,7 @@ public class class228 {
 					Client.isDraggingWidget = false; // L: 10912
 					int var11 = FileSystem.method3638(); // L: 10913
 					if (var11 != -1) { // L: 10914
-						AbstractByteArrayCopier.method4087(var11);
+						AbstractByteArrayCopier.setTempMenuAction(var11);
 					}
 
 					return; // L: 10915


### PR DESCRIPTION
Previously the WidgetPressed event was posted during a FieldHook of the tempMenuAction field. During handling of this event the MenuManager would call setTempMenuAction.

However, the game code then subsequently overrides the actions done by the MenuManager by modifying the MenuEntry.

Replacing the FieldHook with a method hook fixes this issue by slightly delaying the event.