### PR TITLE
PluginManager: Load plugins in reversed order.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
@@ -125,6 +125,7 @@ class ExternalPf4jPluginManager extends DefaultPluginManager
 		}
 
 		List<Path> pluginPaths = pluginRepository.getPluginPaths();
+		Collections.reverse(pluginPaths);
 
 		if (pluginPaths.isEmpty())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ExternalPf4jPluginManager.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
When loading plugins in the default order, lets say
Wintertodt-0.0.1.jar
Wintertodt-0.0.2.jar
Wintertodt-0.0.3.jar

It would load 0.0.1 then detect 0.0.2 and 0.0.3 as duplicates.

By reversing this it would load the newest one and detect the old ones as duplicate.

Tested this and it works fine, no issues.