### PR TITLE
RSClientMixin: Fix multiple plugins with comparing.

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -238,7 +238,7 @@ public abstract class RSClientMixin implements RSClient
 	private boolean isMirrored = false;
 
 	@Inject
-	private boolean comparingAppearance = false;
+	private Integer comparingAppearance = 0;
 
 	@Inject
 	private List<String> outdatedScripts = new ArrayList<>();
@@ -1913,14 +1913,14 @@ public abstract class RSClientMixin implements RSClient
 	@Override
 	public boolean isComparingAppearance()
 	{
-		return comparingAppearance;
+		return comparingAppearance > 0;
 	}
 
 	@Inject
 	@Override
 	public void setComparingAppearance(boolean comparingAppearance)
 	{
-		this.comparingAppearance = comparingAppearance;
+		this.comparingAppearance += comparingAppearance ? 1 : -1;
 	}
 
 	@Inject


### PR DESCRIPTION
At the moment it has 1 boolean value which means if you disable a plugin which needs it all other plugins which need it aswell will stop comparing.
With this it will keep an integer of the amount of plugins, and when it bocomes 0 it will stop comparing.