### PR TITLE
runelite-client: Fix CLI world

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -495,10 +495,6 @@ public class RuneLite
 		RuneLiteSplashScreen.stage(.77, "Starting core interface");
 		clientSessionManager.start();
 
-		//Set the world if specified via CLI args - will not work until clientUI.init is called
-		Optional<Integer> worldArg = Optional.ofNullable(System.getProperty("cli.world")).map(Integer::parseInt);
-		worldArg.ifPresent(this::setWorld);
-
 		// Initialize UI
 		RuneLiteSplashScreen.stage(.80, "Initialize UI");
 		clientUI.init();
@@ -550,6 +546,10 @@ public class RuneLite
 		RuneLiteSplashScreen.close();
 
 		clientUI.show();
+
+		//Set the world if specified via CLI args - will not work until clientUI.init is called
+		Optional<Integer> worldArg = Optional.ofNullable(System.getProperty("cli.world")).map(Integer::parseInt);
+		worldArg.ifPresent(this::setWorld);
 	}
 
 	private void setWorld(int cliWorld)


### PR DESCRIPTION
Setting world through CLI was throwing the following exception:

`2020-12-31 11:42:09 [main] ERROR net.runelite.client.RuneLite - Uncaught exception:
mg: null
	at fj.v(UserComparator9.java:103)
	at ib.o(AbstractArchive.java:370)
	at at.t(class51.java:125)
	at bw.c(SecureRandomCallable.java:1504)
	at client.changeWorld(Client.java)
	at net.runelite.client.RuneLite.setWorld(RuneLite.java:590)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at net.runelite.client.RuneLite.start(RuneLite.java:536)
	at net.runelite.client.RuneLite.main(RuneLite.java:433)`

Judging by the stack trace I'm assuming it's related to the client not being fully loaded yet before trying to set the world.

Moving RuneLite#setWorld to the end of RuneLite#start fixed this issue.