### PR TITLE
client: Seperate system and api version

### DIFF
--- a/runelite-client/src/main/java/com/openosrs/client/OpenOSRS.java
+++ b/runelite-client/src/main/java/com/openosrs/client/OpenOSRS.java
@@ -10,6 +10,7 @@ public class OpenOSRS
 	public static final File OPENOSRS_DIR = new File(System.getProperty("user.home"), ".openosrs");
 	public static final File EXTERNALPLUGIN_DIR = new File(OPENOSRS_DIR, "plugins");
 	public static final String SYSTEM_VERSION;
+	public static final String SYSTEM_API_VERSION;
 
 	public static String uuid = UUID.randomUUID().toString();
 
@@ -25,6 +26,7 @@ public class OpenOSRS
 			e.printStackTrace();
 		}
 		SYSTEM_VERSION = properties.getProperty("oprs.version", "0.0.0");
+		SYSTEM_API_VERSION = properties.getProperty("oprs.api.version", "1.0.0");
 	}
 
 	public static void preload()

--- a/runelite-client/src/main/java/com/openosrs/client/OpenOSRS.java
+++ b/runelite-client/src/main/java/com/openosrs/client/OpenOSRS.java
@@ -26,7 +26,7 @@ public class OpenOSRS
 			e.printStackTrace();
 		}
 		SYSTEM_VERSION = properties.getProperty("oprs.version", "0.0.0");
-		SYSTEM_API_VERSION = properties.getProperty("oprs.api.version", "1.0.0");
+		SYSTEM_API_VERSION = properties.getProperty("oprs.api.version");
 	}
 
 	public static void preload()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/OPRSExternalPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/OPRSExternalPluginManager.java
@@ -34,7 +34,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import static com.openosrs.client.OpenOSRS.EXTERNALPLUGIN_DIR;
-import static com.openosrs.client.OpenOSRS.SYSTEM_VERSION;
+import static com.openosrs.client.OpenOSRS.SYSTEM_API_VERSION;
 import com.openosrs.client.config.OpenOSRSConfig;
 import com.openosrs.client.events.OPRSPluginChanged;
 import com.openosrs.client.events.OPRSRepositoryChanged;
@@ -143,7 +143,7 @@ public class OPRSExternalPluginManager
 	private void initPluginManager()
 	{
 		externalPluginManager = new OPRSExternalPf4jPluginManager(this);
-		externalPluginManager.setSystemVersion(SYSTEM_VERSION);
+		externalPluginManager.setSystemVersion(SYSTEM_API_VERSION);
 	}
 
 	public boolean doesGhRepoExist(String owner, String name)

--- a/runelite-client/src/main/resources/openosrs.properties
+++ b/runelite-client/src/main/resources/openosrs.properties
@@ -1,1 +1,2 @@
+oprs.api.version=1.0.0
 oprs.version=@open.osrs.version@


### PR DESCRIPTION
setSystemVersion for PF4J is used to determine if an external plugin can be loaded without API mismatches. The name can be kinda misleading. Bumping this version every client update causes externals not to work until they have been recompiled against the latest client version even if the API hasn't changed.

This version follows the SEMVER standard and we should keep this in mind from now on when pushing out new client releases.

Given a version number MAJOR.MINOR.PATCH, increment the:

MAJOR version when you make incompatible API changes,
MINOR version when you add functionality in a backwards compatible manner, and
PATCH version when you make backwards compatible bug fixes.