### PR TITLE
api: Bug fix of getInteracting() in Projectile mixin

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSProjectileMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSProjectileMixin.java
@@ -80,7 +80,7 @@ public abstract class RSProjectileMixin implements RSProjectile
 		{
 			int idx = -interactingIndex - 1;
 
-			if (idx == client.getLocalInteractingIndex())
+			if (idx == client.getLocalPlayerIndex())
 			{
 				return client.getLocalPlayer();
 			}


### PR DESCRIPTION
Fixed bug where Projectile.getInteracting() returns local player if the projectile is targeting a Player that the local player is interacting with.
It should return that Player instead of the local player.