### PR TITLE
api: adds HealthBarUpdated event and the corresponding mixin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/HealthBarUpdated.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/HealthBarUpdated.java
@@ -24,22 +24,26 @@
  */
 package net.runelite.api.events;
 
-import lombok.Data;
+import lombok.Value;
 import net.runelite.api.Actor;
 import net.runelite.api.Hitsplat;
 
 /**
  * An event called when an {@link Actor} health bar is updated from a {@link Hitsplat}.
+ * <p>
+ * This event is called when the health bar first appears and when the client gets new information
+ * about the health bar of the actor. It does not fire when the health bar disappears.
+ * The event will still fire even if the health ratio did not change for example from a 0 hitsplat.
  */
-@Data
+@Value
 public class HealthBarUpdated
 {
 	/**
 	 * The actor the hitsplat was applied to.
 	 */
-	private Actor actor;
+	Actor actor;
 	/**
 	 * The updated health ratio.
 	 */
-	private int healthRatio;
+	int healthRatio;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/HealthBarUpdated.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/HealthBarUpdated.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Satoshi Oda <https://github.com/rokahakor>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.events;
+
+import net.runelite.api.Actor;
+import net.runelite.api.Hitsplat;
+import lombok.Data;
+
+/**
+ * An event called when an {@link Actor} health bar is updated from a {@link Hitsplat}.
+ */
+@Data
+public class HealthBarUpdated
+{
+    /**
+     * The actor the hitsplat was applied to.
+     */
+    private Actor actor;
+    /**
+     * The updated health ratio.
+     */
+    private int healthRatio;
+}

--- a/runelite-api/src/main/java/net/runelite/api/events/HealthBarUpdated.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/HealthBarUpdated.java
@@ -24,9 +24,9 @@
  */
 package net.runelite.api.events;
 
+import lombok.Data;
 import net.runelite.api.Actor;
 import net.runelite.api.Hitsplat;
-import lombok.Data;
 
 /**
  * An event called when an {@link Actor} health bar is updated from a {@link Hitsplat}.
@@ -34,12 +34,12 @@ import lombok.Data;
 @Data
 public class HealthBarUpdated
 {
-    /**
-     * The actor the hitsplat was applied to.
-     */
-    private Actor actor;
-    /**
-     * The updated health ratio.
-     */
-    private int healthRatio;
+	/**
+	 * The actor the hitsplat was applied to.
+	 */
+	private Actor actor;
+	/**
+	 * The updated health ratio.
+	 */
+	private int healthRatio;
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -270,9 +270,7 @@ public abstract class RSActorMixin implements RSActor
 			this.setDead(true);
 		}
 
-		final HealthBarUpdated event = new HealthBarUpdated();
-		event.setActor(this);
-		event.setHealthRatio(healthRatio);
+		final HealthBarUpdated event = new HealthBarUpdated(this, healthRatio);
 		client.getCallbacks().post(event);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -38,6 +38,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.HealthBarUpdated;
 import net.runelite.api.events.GraphicChanged;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.OverheadTextChanged;
@@ -268,6 +269,11 @@ public abstract class RSActorMixin implements RSActor
 
 			this.setDead(true);
 		}
+
+		final HealthBarUpdated event = new HealthBarUpdated();
+		event.setActor(this);
+		event.setHealthRatio(healthRatio);
+		client.getCallbacks().post(event);
 	}
 
 	/**


### PR DESCRIPTION
Adds the HealthBarUpdated event and changes to support the event in RSActorMixin.

Getting the healthbar ratio in onHitsplatApplied results in the old healthbar ratio being used since the healthbar hasn't been updated yet from the hitsplat.