### PR TITLE
mixins: Add setMinimapReceivesClicks

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1404,6 +1404,8 @@ public interface Client extends GameEngine
 	 */
 	SpritePixels drawInstanceMap(int z);
 
+	void setMinimapReceivesClicks(boolean minimapReceivesClicks);
+
 	/**
 	 * Executes a client script from the cache
 	 * <p>

--- a/runelite-mixins/src/main/java/net/runelite/mixins/MinimapMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/MinimapMixin.java
@@ -25,8 +25,11 @@
 package net.runelite.mixins;
 
 import static net.runelite.api.Perspective.SCENE_SIZE;
+import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.api.widgets.Widget;
 import net.runelite.rs.api.RSClient;
 import net.runelite.rs.api.RSScene;
 import net.runelite.rs.api.RSSpritePixels;
@@ -34,6 +37,28 @@ import net.runelite.rs.api.RSSpritePixels;
 @Mixin(RSClient.class)
 public abstract class MinimapMixin implements RSClient
 {
+	@Inject
+	private static boolean rl$minimapReceivesClicks = true;
+
+	@Copy("checkIfMinimapClicked")
+	@Replace("checkIfMinimapClicked")
+	public static void copy$checkIfMinimapClicked(Widget var0, int var1, int var2)
+	{
+		if (!rl$minimapReceivesClicks)
+		{
+			return;
+		}
+
+		copy$checkIfMinimapClicked(var0, var1, var2);
+	}
+
+	@Inject
+	@Override
+	public void setMinimapReceivesClicks(boolean minimapReceivesClicks)
+	{
+		rl$minimapReceivesClicks = minimapReceivesClicks;
+	}
+
 	@Inject
 	@Override
 	public RSSpritePixels drawInstanceMap(int z)


### PR DESCRIPTION
Lets plugins disable the implementation of checkIfMinimapClicked

This is useful for plugins that add custom menu entries, which otherwise
would trigger in addition to a minimap click