### PR TITLE
client: Make overlays aware of focus

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -63,6 +63,9 @@ public abstract class Overlay implements LayoutableRenderableEntity
 	@Setter(AccessLevel.PROTECTED)
 	private boolean dragTargetable;
 
+	@Setter(AccessLevel.PROTECTED)
+	private boolean hasFocus;
+
 	protected Overlay()
 	{
 		plugin = null;
@@ -94,6 +97,14 @@ public abstract class Overlay implements LayoutableRenderableEntity
 	}
 
 	public void onMouseOver()
+	{
+	}
+
+	public void onMouseEnter()
+	{
+	}
+
+	public void onMouseExit()
 	{
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -271,6 +271,8 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 				final Rectangle bounds = overlay.getBounds();
 				final Dimension dimension = bounds.getSize();
 				final Point preferredLocation = overlay.getPreferredLocation();
+				final boolean hadFocus = overlay.isHasFocus();
+				boolean hasFocus = false;
 				Point location;
 
 				// If the final position is not modified, layout it
@@ -352,8 +354,22 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 							menuEntries = createRightClickMenuEntries(overlay);
 						}
 
+						hasFocus = true;
+
+						if (!hadFocus)
+						{
+							overlay.setHasFocus(true);
+							overlay.onMouseEnter();
+						}
+
 						overlay.onMouseOver();
 					}
+				}
+
+				if (hadFocus && !hasFocus)
+				{
+					overlay.setHasFocus(false);
+					overlay.onMouseExit();
 				}
 			}
 		}


### PR DESCRIPTION
Also provide mouseEnter & mouseExit hooks

This is helpful for overlays that wish to add custom menu entries
or otherwise change their behavior depending on if they have focus