### PR TITLE
client: Make overlays aware of mouse focus

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -97,6 +97,14 @@ public abstract class Overlay implements LayoutableRenderableEntity
 	{
 	}
 
+	public void onMouseEnter()
+	{
+	}
+
+	public void onMouseExit()
+	{
+	}
+
 	/**
 	 * Called when an overlay is dragged onto this, if dragTargetable is true.
 	 * Return true to consume the mouse event and prevent the other

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -107,6 +107,10 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 	private boolean isResizeable;
 	private OverlayBounds emptySnapCorners, snapCorners;
 
+	// focused overlay
+	private Overlay focusedOverlay;
+	private Overlay prevFocusedOverlay;
+
 	@Inject
 	private OverlayRenderer(
 		final Client client,
@@ -173,6 +177,14 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 	public void onBeforeRender(BeforeRender event)
 	{
 		menuEntries = null;
+
+		if (focusedOverlay == null && prevFocusedOverlay != null)
+		{
+			prevFocusedOverlay.onMouseExit();
+		}
+
+		prevFocusedOverlay = focusedOverlay;
+		focusedOverlay = null;
 
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
@@ -350,6 +362,20 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 						if (menuEntries == null)
 						{
 							menuEntries = createRightClickMenuEntries(overlay);
+						}
+
+						if (focusedOverlay == null)
+						{
+							focusedOverlay = overlay;
+							if (focusedOverlay != prevFocusedOverlay)
+							{
+								if (prevFocusedOverlay != null)
+								{
+									prevFocusedOverlay.onMouseExit();
+								}
+
+								overlay.onMouseEnter();
+							}
 						}
 
 						overlay.onMouseOver();


### PR DESCRIPTION
This is helpful for plugins that wish to show overlays that perform
actions when they have mouse focus, such as offering left click actions.

While it's possible to track this within the overlay itself it is difficult
to do correctly when considering overlapping overlays and overlays being
removed while they have focus.