### PR TITLE
api: rename getRsOrientation -> getModelOrientation inline with upstream

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
@@ -97,7 +97,7 @@ public abstract class RSGameObjectMixin implements RSGameObject
 	@Override
 	public Shape getClickbox()
 	{
-		return Perspective.getClickbox(client, getModel(), getRsOrientation(), getLocalLocation());
+		return Perspective.getClickbox(client, getModel(), getModelOrientation(), getLocalLocation());
 	}
 
 	@Inject
@@ -113,14 +113,14 @@ public abstract class RSGameObjectMixin implements RSGameObject
 
 		int tileHeight = Perspective.getTileHeight(client, new LocalPoint(getX(), getY()), client.getPlane());
 
-		return model.getConvexHull(getX(), getY(), getRsOrientation(), tileHeight);
+		return model.getConvexHull(getX(), getY(), getModelOrientation(), tileHeight);
 	}
 
 	@Override
 	@Inject
 	public Angle getOrientation()
 	{
-		int orientation = getRsOrientation();
+		int orientation = getModelOrientation();
 		int rotation = (getFlags() >> 6) & 3;
 		return new Angle(rotation * 512 + orientation);
 	}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGameObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGameObject.java
@@ -32,7 +32,7 @@ public interface RSGameObject extends GameObject
 	int getHeight();
 
 	@Import("orientation")
-	int getRsOrientation();
+	int getModelOrientation();
 
 	@Import("tag")
 	@Override


### PR DESCRIPTION
java.lang.AbstractMethodError: Receiver class hf does not define or inherit an implementation of the resolved method 'abstract int getModelOrientation()' of interface net.runelite.api.GameObject.
    at net.runelite.client.ui.overlay.outline.ModelOutlineRenderer.drawOutline(ModelOutlineRenderer.java:1028)
    at net.runelite.client.ui.overlay.outline.ModelOutlineRenderer.drawOutline(ModelOutlineRenderer.java:1155)
    at net.runelite.client.plugins.objectindicators.ObjectIndicatorsOverlay.render(ObjectIndicatorsOverlay.java:107)
    at net.runelite.client.ui.overlay.OverlayRenderer.safeRender(OverlayRenderer.java:773)
    at net.runelite.client.ui.overlay.OverlayRenderer.renderOverlays(OverlayRenderer.java:271)
    at net.runelite.client.ui.overlay.OverlayRenderer.renderOverlayLayer(OverlayRenderer.java:205)
    at net.runelite.client.callback.Hooks.drawScene(Hooks.java:434)
    at gp.ac(Scene.java:310)
    at dr.gr(UserComparator9.java:4688)
    at bq.im(PcmPlayer.java:9492)
    at bi.ig(SoundSystem.java:9381)
    at client.gb(Client.java:4456)
    at client.ak(Client.java:1322)
    at aa.p(GameEngine.java:362)
    at aa.run(GameEngine.java:316)
    at java.base/java.lang.Thread.run(Thread.java:834)





