### PR TITLE
configmanager: temp fix to prevent plugin-hub crashes

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object ProjectVersions {
     const val launcherVersion = "2.2.0"
     const val rlVersion = "1.8.5"
 
-    const val openosrsVersion = "4.15.7"
+    const val openosrsVersion = "4.15.8"
 
     const val rsversion = 201
     const val cacheversion = 165

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -45,6 +45,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -417,6 +418,11 @@ public class ConfigManager
 		return getConfiguration(groupName, null, key, clazz);
 	}
 
+	public <T> Object getConfiguration(String groupName, String key, Type clazz)
+	{
+		return getConfiguration(groupName, null, key, clazz);
+	}
+
 	public <T> T getRSProfileConfiguration(String groupName, String key, Class<T> clazz)
 	{
 		String rsProfileKey = this.rsProfileKey;
@@ -426,6 +432,23 @@ public class ConfigManager
 		}
 
 		return getConfiguration(groupName, rsProfileKey, key, clazz);
+	}
+
+	public <T> T getConfiguration(String groupName, String profile, String key, Type clazz)
+	{
+		String value = getConfiguration(groupName, profile, key);
+		if (!Strings.isNullOrEmpty(value))
+		{
+			try
+			{
+				return (T) stringToObject(value, (Class<?>) clazz);
+			}
+			catch (Exception e)
+			{
+				log.warn("Unable to unmarshal {} ", getWholeKey(groupName, profile, key), e);
+			}
+		}
+		return null;
 	}
 
 	public <T> T getConfiguration(String groupName, String profile, String key, Class<T> clazz)


### PR DESCRIPTION
newly compiled plugin-hub plugins use `getConfiguration(String groupName, String key, Type clazz)` and not `getConfiguration(String groupName, String key, Class<T> clazz)`

this temp fix prevents plugins from crashing your client, should be removed once OPRS complete the config merge