### PR TITLE
client: update menu entries that were modified by the MenuEntryAdded event

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1024,6 +1024,17 @@ public abstract class RSClientMixin implements RSClient
 				menuArgument2
 			);
 			client.getCallbacks().post(menuEntryAdded);
+
+			if (menuEntryAdded.isModified() && client.getMenuOptionCount() == optionCount)
+			{
+				client.getMenuOptions()[tmpOptionsCount] = menuEntryAdded.getOption();
+				client.getMenuTargets()[tmpOptionsCount] = menuEntryAdded.getTarget();
+				client.getMenuOpcodes()[tmpOptionsCount] = menuEntryAdded.getIdentifier();
+				client.getMenuIdentifiers()[tmpOptionsCount] = menuEntryAdded.getType();
+				client.getMenuArguments1()[tmpOptionsCount] = menuEntryAdded.getActionParam0();
+				client.getMenuArguments2()[tmpOptionsCount] = menuEntryAdded.getActionParam1();
+				client.getMenuForceLeftClick()[tmpOptionsCount] = menuEntryAdded.isForceLeftClick();
+			}
 		}
 	}
 


### PR DESCRIPTION
Looks like this part was forgotten when merging the [new menu entry api](https://github.com/open-osrs/runelite/commit/a42c845ad3c7cd64b1c738134b3dd874b83716d6#diff-42fdba36fa93bd0601d7e7acb5dc38d3b95f58bdcb4b141b72c504255fa61ccbL865)