### PR TITLE
client: fix hotkey listener double firing hotkey released event

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
@@ -89,7 +89,6 @@ public abstract class HotkeyListener implements KeyListener
 			}
 			isPressed = false;
 			isConsumingTyped = false;
-			hotkeyReleased();
 		}
 	}
 


### PR DESCRIPTION
If you look at upstream you can see our behaviour is drastically different. It results in the hotkey released event being double fired.