### PR TITLE
client: Fix enumset config panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -1019,7 +1019,7 @@ class ConfigPanel extends PluginPanel
 
 			ToggleButton checkbox = new ToggleButton(option);
 			checkbox.setBackground(ColorScheme.DARK_GRAY_COLOR);
-			checkbox.setSelected(enumSet.toString().contains(String.valueOf(obj)));
+			checkbox.setSelected(enumSet.contains(obj));
 			jcheckboxes.add(checkbox);
 
 			enumsetLayout.add(checkbox);


### PR DESCRIPTION
Dunno why enumSet and enum were being converted to strings to check contains. It resulted in a bug where other enums could get toggled if their names were contained in the enumset string due to an enum name being a substring of another enum name.