### PR TITLE
api: add hidden state to renderable

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Renderable.java
+++ b/runelite-api/src/main/java/net/runelite/api/Renderable.java
@@ -42,4 +42,7 @@ public interface Renderable extends Node
 	void setModelHeight(int modelHeight);
 
 	void draw(int orientation, int pitchSin, int pitchCos, int yawSin, int yawCos, int x, int y, int z, long hash);
+
+	void setHidden(boolean hidden);
+	boolean isHidden();
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -131,6 +131,14 @@ public abstract class EntityHiderMixin implements RSScene
 			return true;
 		}
 
+		if (entity instanceof RSRenderable)
+		{
+			if (((RSRenderable) entity).isHidden())
+			{
+				return false;
+			}
+		}
+
 		if (entity instanceof RSPlayer)
 		{
 			RSPlayer player = (RSPlayer) entity;

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSRenderableMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSRenderableMixin.java
@@ -1,0 +1,24 @@
+package net.runelite.mixins;
+
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.rs.api.RSRenderable;
+
+@Mixin(RSRenderable.class)
+public abstract class RSRenderableMixin implements RSRenderable
+{
+	@Inject
+	private boolean hidden = false;
+
+	@Inject
+	public void setHidden(boolean hidden)
+	{
+		this.hidden = hidden;
+	}
+
+	@Inject
+	public boolean isHidden()
+	{
+		return hidden;
+	}
+}


### PR DESCRIPTION
Allows for object oriented style of entity hiding. Works on NPCs Players Projectiles. Useful for hiding specific objects.