### PR TITLE
api: Add low level control methods for the login screen background

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -2271,6 +2271,16 @@ public interface Client extends GameEngine
 	void setLoginScreen(SpritePixels pixels);
 
 	/**
+	 * Low level control over the login screen background.
+	 * Useful when changing the login screen background every frame, for example for playing a video.
+	 * A typical update cycle would be:
+	 * 1. setLoginScreenBackground(pixels) 2. setLoginScreenLeftTitleSprite() 3. setLoginScreenRightTitleSprite()
+	 */
+	void setLoginScreenBackground(SpritePixels pixels);
+	void setLoginScreenLeftTitleSprite();
+	void setLoginScreenRightTitleSprite();
+
+	/**
 	 * Sets whether the flames on the login screen should be rendered
 	 */
 	void setShouldRenderLoginScreenFire(boolean val);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/LoginScreenMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/LoginScreenMixin.java
@@ -77,6 +77,26 @@ public abstract class LoginScreenMixin implements RSClient
 	}
 
 	@Inject
+	public void setLoginScreenBackground(SpritePixels background)
+	{
+		assert client.isClientThread() : "setLoginScreen must be called on client thread";
+		loginScreenBackground = background;
+		client.clearLoginScreen(false);
+	}
+
+	@Inject
+	public void setLoginScreenLeftTitleSprite()
+	{
+		setLeftTitleSprite(0);
+	}
+
+	@Inject
+	public void setLoginScreenRightTitleSprite()
+	{
+		setRightTitleSprite(0);
+	}
+
+	@Inject
 	@FieldHook("leftTitleSprite")
 	static void setLeftTitleSprite(int idx)
 	{


### PR DESCRIPTION
Expose methods to specifically control part of the update cycle of the login screen. From a high level point of view this is no different than setLoginScreen(SpritePixels pixels) however the gamestate change is quite heavy and unnecessary when setting the login screen background every frame. Using setLoginScreen(SpritePixels pixels) for video playback results in some stutter for me.

I need this for a plugin that plays a video on the login screen but I understand if this is too specific to be included in the project.