### PR TITLE
client: Cache Overlay Mixin Addition

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/overlay/OverlayIndex.java
+++ b/runelite-api/src/main/java/net/runelite/api/overlay/OverlayIndex.java
@@ -27,8 +27,10 @@ package net.runelite.api.overlay;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,6 +39,15 @@ public class OverlayIndex
 {
 	@Getter
 	private static final Set<Integer> overlays = new HashSet<>();
+
+	/**
+	 * Stores transformer callbacks for given cache object.
+	 * The key is of format (indexId << 16 | archiveId).
+	 * The value is of format:
+	 * byte[] function(originalBytesFromCache){ if (doNothing) return originalBytesFromCache; else return customBytes; }
+	 */
+	@Getter
+	private static final HashMap<Integer, Function<byte[], byte[]>> cacheTransformers = new HashMap<>();
 
 	static
 	{
@@ -53,6 +64,16 @@ public class OverlayIndex
 		{
 			log.warn("unable to load overlay index", ex);
 		}
+	}
+
+	public static boolean hasCacheTransformer(int indexId, int archiveId)
+	{
+		return cacheTransformers.containsKey(indexId << 16 | archiveId);
+	}
+
+	public static Function<byte[], byte[]> getCacheTransformer(int indexId, int archiveId)
+	{
+		return cacheTransformers.get(indexId << 16 | archiveId);
 	}
 
 	public static boolean hasOverlay(int indexId, int archiveId)

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSAbstractArchiveMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSAbstractArchiveMixin.java
@@ -45,6 +45,11 @@ public abstract class RSAbstractArchiveMixin implements RSAbstractArchive
 		final byte[] rsData = copy$getConfigData(groupId, fileId);
 		final int archiveId = ((RSArchive) this).getIndex();
 
+		if (OverlayIndex.hasCacheTransformer(archiveId, groupId))
+		{
+			return OverlayIndex.getCacheTransformer(archiveId, groupId).apply(rsData);
+		}
+
 		if (!OverlayIndex.hasOverlay(archiveId, groupId))
 		{
 			return rsData;


### PR DESCRIPTION
Useful for modifying the byte arrays from cache when requested by the client. This can be easily applied to load custom cache compatible files such as rs2 models (for runtime model replacing). 