### PR TITLE
project: fix warning dialog

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/openosrs/externals/ExternalPluginManagerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/openosrs/externals/ExternalPluginManagerPanel.java
@@ -11,7 +11,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import javax.inject.Inject;
 import javax.swing.ImageIcon;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/openosrs/externals/ExternalPluginManagerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/openosrs/externals/ExternalPluginManagerPanel.java
@@ -288,7 +288,7 @@ public class ExternalPluginManagerPanel extends PluginPanel
 		label.setPreferredSize(new Dimension(450, 200));
 		label.setFont(font);
 
-		return JOptionPane.showOptionDialog(new JFrame(),
+		return JOptionPane.showOptionDialog(ClientUI.getFrame(),
 			label,
 			"Account security warning",
 			JOptionPane.YES_NO_OPTION,


### PR DESCRIPTION
If you have `Always on top` enabled on the client and the warning dialog appears behind the client then you get stuck where you can't minimize or interact with the client nor accept the warning dialog to close it.